### PR TITLE
fixed categorical filters

### DIFF
--- a/src/app/sidebar/histogram/histogram.component.ts
+++ b/src/app/sidebar/histogram/histogram.component.ts
@@ -555,47 +555,21 @@ export class HistogramComponent implements OnInit, AfterViewInit, OnChanges, OnD
     this.filter.clear();
 
     if (effectiveType === 'categorical') {
-      // For categorical: Filter by actual feature values
-      // Values can be either normalized [0,1] or raw integers depending on scaling config
-
-      // Get the number of actual categories from the non-zero bins
-      const nonZeroBins = Object.entries(this.histogramData)
-        .filter(([, v]) => v !== 0)
-        .map(([k]) => +k)
-        .sort((a, b) => a - b);
-
-      const numCategories = nonZeroBins.length;
-
-      // Determine if data is raw label-encoded integers (not normalized)
-      // Raw integers: min=0, max=numCategories-1 (e.g., 0,1,2,3,4 for 5 categories)
-      // Normalized: any other pattern (data was scaled to [0,1])
-      const isRawIntegers = this.featureMin === 0 && this.featureMax === numCategories - 1 && numCategories > 1;
+      // Glyph feature values are ALWAYS stored in normalized [0,1] space (both
+      // process.py and the wizard normalize before storing). Histogram bins are
+      // uniformly distributed across the bin index range, so bin n corresponds to
+      // normalized value range [n/totalBins, (n+1)/totalBins].
+      //
+      // This works for:
+      //   - process.py output (20 fixed bins, multiple categories may share a bin)
+      //   - wizard uploads (one bin per category, N bins for N categories)
+      //   - any future normalized-data binning scheme
+      const binWidth = 1 / totalBins;
+      const epsilon = binWidth * 1e-6;
 
       selectedBins.forEach(bin => {
-        // Find which category index this bin corresponds to
-        const categoryIndex = nonZeroBins.indexOf(bin);
-
-        if (categoryIndex === -1) {
-          return;
-        }
-
-        let filterMin: number;
-        let filterMax: number;
-
-        if (isRawIntegers) {
-          // Data is raw integers: category index IS the value
-          // With tolerance for float comparison
-          filterMin = categoryIndex - 0.5;
-          filterMax = categoryIndex + 0.5;
-        } else {
-          // Data is normalized [0,1]: use category index to compute normalized value
-          // category i → i / (N-1) for N categories
-          const normalizedValue = numCategories === 1 ? 0 : categoryIndex / (numCategories - 1);
-          const tolerance = 0.01;
-          filterMin = Math.max(0, normalizedValue - tolerance);
-          filterMax = Math.min(1, normalizedValue + tolerance);
-        }
-
+        const filterMin = bin * binWidth - epsilon;
+        const filterMax = (bin + 1) * binWidth + epsilon;
         this.categoryFilter.addRange(filterMin, filterMax);
       });
     } else {

--- a/src/app/sidebar/sidebar.component.ts
+++ b/src/app/sidebar/sidebar.component.ts
@@ -116,7 +116,38 @@ export class SidebarComponent implements OnInit, OnDestroy {
           this.ngZone.run(() => {
             this.features = metaData.features;
             this.featureIds = Object.keys(this.features);
-            this.selectedColorAttribute = this.config.colorFeature;
+
+            // Decide which color feature to use for the new dataset
+            const desired = this.config.colorFeature;
+            const colorFeature =
+              desired && this.featureIds.includes(desired)
+                ? desired
+                : this.schema?.color && this.featureIds.includes(this.schema.color)
+                  ? this.schema.color
+                  : this.featureIds[0];
+
+            let configChanged = false;
+            if (colorFeature && colorFeature !== this.config.colorFeature) {
+              this.config.colorFeature = colorFeature;
+              configChanged = true;
+            }
+            this.selectedColorAttribute = colorFeature ?? '';
+
+            // Ensure the active color scale matches the new feature's type
+            // (e.g. don't keep a categorical scale on a numeric feature after a dataset switch)
+            if (colorFeature) {
+              const featureType = this.schema?.types?.[colorFeature];
+              const currentScale = this.colorScales.find(s => s.id === this.config.colorRange);
+              if (featureType && currentScale && currentScale.type !== featureType) {
+                const matchingScale = this.colorScales.find(s => s.type === featureType)?.id;
+                if (matchingScale !== undefined) {
+                  this.config.colorRange = matchingScale;
+                  configChanged = true;
+                }
+              }
+            }
+
+            if (configChanged) this.config.updateConfiguration();
             this.selectedColorScaleId = this.config.colorRange;
           });
         }


### PR DESCRIPTION
## Fix categorical filter selection mapping

Closes #68

### Summary

Categorical filters in the sidebar histogram highlight the wrong items. Two related bugs were caused by incorrect bin → value mapping:

- **Wrong items greyed out / wrong items kept colored** when filtering by a categorical feature
- **Stale color scale on dataset switch** — categorical scale persisted on a numeric feature (and vice versa)

### Root causes

**1. Bin → filter range mismatch.** Glyph feature values are always stored in normalized `[0, 1]` space (both `tools/process.py` and the wizard's `preprocessing_processor_config.py` normalize before writing). But `featureMin`/`featureMax` in `meta.features[].min/max` differ per pipeline:

| Pipeline    | `featureMin..featureMax`              | Bin count          | Categories per bin |
| ----------- | ------------------------------------- | ------------------ | ------------------ |
| `process.py`| `0..1` (post-normalization stats)     | 20 fixed           | possibly several   |
| Wizard      | `0..N-1` (pre-normalization integers) | N (one per category) | exactly one      |

The old filter logic interpolated `categoryIndex / (numCategories - 1)` with a `±0.01` tolerance — too narrow to catch the multiple categories sharing a bin in the `process.py` case, and it conflated bin index with category index in the wizard case.

**2. Color scale type not revalidated on dataset switch.** When loading a new dataset, the active color feature was reset to a valid one, but the color *scale* (categorical / linear) wasn't checked against the new feature's type.

### Changes

**`src/app/sidebar/histogram/histogram.component.ts`**

- Categorical filter now uses `[bin / totalBins, (bin + 1) / totalBins]` directly in normalized space — the same bin-uniform mapping the histogram itself uses for display. Works for both pipelines and for bins shared by multiple categories.
- Removed the `isRawIntegers` heuristic and its diverging branches.

**`src/app/sidebar/sidebar.component.ts`**

- On dataset load, validate the active color feature against the new dataset's `featureIds`; fall back to `schema.color` or the first feature when invalid.
- Always re-check the active color scale's `type` against the resolved color feature's type and swap to a matching scale when they diverge.
