### PR TITLE
feat(a13): Spaltenauswahl für Projektion von Schritt 3 nach Schritt 4

### DIFF
--- a/src/app/preprocessing-wizard/shared/constants/step-info.ts
+++ b/src/app/preprocessing-wizard/shared/constants/step-info.ts
@@ -15,16 +15,18 @@ export const STEP_INFO: Record<number, StepInfo> = {
   },
   1: {
     title: 'Select Columns',
-    purpose: 'Choose which columns to include in your visualization. Deselect ID fields and irrelevant columns.',
+    purpose:
+      'Choose which columns to keep under consideration for the analysis. Deselect ID fields and irrelevant columns.',
   },
   2: {
     title: 'Configure Data & Features',
     purpose:
-      'Configure encoding, scaling, and data cleaning settings for each column. Select a column to view and edit its options.',
+      'Configure data types, encoding, scaling, outliers, and cleaning for each column. Select a column to view and edit its options.',
   },
   3: {
     title: 'Visualization Settings',
-    purpose: 'Configure glyph features with live preview, set color mapping, and select projection methods.',
+    purpose:
+      'Choose which columns feed the projection and pick the projection methods, then configure glyph features and color mapping.',
   },
   4: {
     title: 'Review & Process',

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.html
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.html
@@ -58,7 +58,6 @@
             </div>
             <div class="list-footer">
               <span class="list-count">{{ filteredColumns.length }} of {{ columns.length }}</span>
-              <span class="projection-count">{{ getProjectionCount() }} in projection</span>
             </div>
           </div>
 
@@ -86,19 +85,6 @@
                       <span class="issue-badge outliers">{{ colState.outlierCount }} outliers</span>
                     }
                   </div>
-                </div>
-                <div
-                  class="item-projection"
-                  (click)="$event.stopPropagation()"
-                  (keydown.enter)="$event.stopPropagation()"
-                  tabindex="0"
-                >
-                  <input
-                    type="checkbox"
-                    [checked]="colState.config.includeInProjection"
-                    (change)="toggleProjection(colState.column.name)"
-                    title="Include in projection"
-                  />
                 </div>
               </div>
             }
@@ -325,17 +311,6 @@
               </div>
             }
 
-            <!-- Projection -->
-            <div class="config-section projection-section">
-              <label class="projection-label">
-                <input
-                  type="checkbox"
-                  [checked]="selectedColumn.config.includeInProjection"
-                  (change)="toggleProjection(selectedColumn.column.name)"
-                />
-                <span>Include in projection</span>
-              </label>
-            </div>
           } @else {
             <div class="no-selection">
               <span class="material-icons">touch_app</span>

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.ts
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.ts
@@ -36,7 +36,7 @@ interface ColumnConfigState {
 })
 export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
   readonly primaryLabel = 'Continue to Visualization Settings';
-  readonly disabledHint = 'Please include at least one column in projection to continue.';
+  readonly disabledHint = '';
 
   columns: ColumnConfigState[] = [];
   filteredColumns: ColumnConfigState[] = [];
@@ -308,19 +308,6 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
     });
   }
 
-  toggleProjection(columnName: string): void {
-    const colState = this.columns.find(c => c.column.name === columnName);
-    if (colState) {
-      const newValue = !colState.config.includeInProjection;
-      // Update service
-      this.preprocessingService.updateColumnConfig(columnName, {
-        includeInProjection: newValue,
-      });
-      // Update local state to trigger template re-render
-      colState.config.includeInProjection = newValue;
-    }
-  }
-
   toggleRemoveDuplicates(): void {
     this.cleaningConfig.removeDuplicates = !this.cleaningConfig.removeDuplicates;
     this.preprocessingService.updateCleaningConfig({
@@ -415,13 +402,10 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
     return state.dataProfile.columns.map(c => c.name);
   }
 
-  getProjectionCount(): number {
-    return this.columns.filter(c => c.config.includeInProjection).length;
-  }
-
   canProceed(): boolean {
-    // At least one column must be included in projection
-    return this.getProjectionCount() > 0;
+    // Data configuration always has valid defaults; column selection for the
+    // projection now happens in Step 4 (Visualization Settings).
+    return true;
   }
 
   proceed(): void {

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -251,18 +251,29 @@
             Projection Columns
             <app-help-tooltip [helpText]="HELP_TEXT.general.projection"></app-help-tooltip>
           </h3>
-          <span class="projection-count">{{ getProjectionCount() }}/{{ projectionColumns.length }}</span>
+          <span class="projection-count">{{ getProjectionCount() }} / {{ projectionColumns.length }} included</span>
         </div>
         <p class="panel-description">Choose which columns feed the dimensionality reduction.</p>
 
-        <div class="projection-columns-actions">
-          <button type="button" class="btn-link" (click)="setAllProjectionColumns(true)">Select all</button>
-          <button type="button" class="btn-link" (click)="setAllProjectionColumns(false)">Clear</button>
+        <div class="projection-columns-list-header">
+          <input
+            type="checkbox"
+            class="master-checkbox"
+            [checked]="allColumnsInProjection()"
+            [indeterminate]="someColumnsInProjection()"
+            (change)="onToggleAllProjection()"
+            title="Select all columns"
+          />
+          <span class="master-label">All columns</span>
         </div>
 
         <div class="projection-columns-list">
           @for (entry of projectionColumns; track entry.column.name) {
-            <label class="projection-column-item" [class.selected]="entry.config.includeInProjection">
+            <label
+              class="projection-column-item"
+              [class.selected]="entry.config.includeInProjection"
+              [class.excluded]="!entry.config.includeInProjection"
+            >
               <input
                 type="checkbox"
                 [checked]="entry.config.includeInProjection"

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -241,8 +241,49 @@
       </div>
     </div>
 
-    <!-- ====== Projection Methods (two-column grid) ====== -->
-    <div class="config-panel projection-panel">
+    <!-- ====== Projection Options (columns + method, two-column layout) ====== -->
+    <div class="projection-options-two-col">
+      <!-- LEFT: Columns feeding the projection -->
+      <div class="config-panel projection-columns-panel">
+        <div class="projection-columns-header">
+          <h3>
+            <span class="material-icons">view_column</span>
+            Projection Columns
+            <app-help-tooltip [helpText]="HELP_TEXT.general.projection"></app-help-tooltip>
+          </h3>
+          <span class="projection-count">{{ getProjectionCount() }}/{{ projectionColumns.length }}</span>
+        </div>
+        <p class="panel-description">Choose which columns feed the dimensionality reduction.</p>
+
+        <div class="projection-columns-actions">
+          <button type="button" class="btn-link" (click)="setAllProjectionColumns(true)">Select all</button>
+          <button type="button" class="btn-link" (click)="setAllProjectionColumns(false)">Clear</button>
+        </div>
+
+        <div class="projection-columns-list">
+          @for (entry of projectionColumns; track entry.column.name) {
+            <label class="projection-column-item" [class.selected]="entry.config.includeInProjection">
+              <input
+                type="checkbox"
+                [checked]="entry.config.includeInProjection"
+                (change)="toggleColumnProjection(entry.column.name)"
+              />
+              <span class="col-name">{{ entry.column.name }}</span>
+              <app-data-type-badge [dataType]="entry.column.dataType"></app-data-type-badge>
+            </label>
+          }
+        </div>
+
+        @if (getProjectionCount() === 0) {
+          <div class="validation-warning">
+            <span class="material-icons">warning</span>
+            <span>Select at least one column for the projection</span>
+          </div>
+        }
+      </div>
+
+      <!-- RIGHT: Projection method selection -->
+      <div class="config-panel projection-panel">
       <div class="projection-panel-header">
         <h3>
           <span class="material-icons">settings</span>
@@ -351,6 +392,7 @@
           </div>
         }
       }
+      </div>
     </div>
   </div>
 </div>

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -649,6 +649,130 @@
   }
 
   // ============================================================================
+  // Projection Options (two-column: columns + method)
+  // ============================================================================
+
+  .projection-options-two-col {
+    display: grid;
+    grid-template-columns: 2fr 3fr;
+    gap: 16px;
+    align-items: start;
+
+    // Panels inside the grid should not add their own bottom margin
+    .config-panel {
+      margin-bottom: 0;
+    }
+  }
+
+  .projection-columns-panel {
+    display: flex;
+    flex-direction: column;
+    max-height: 420px;
+
+    .projection-columns-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 8px;
+
+      h3 {
+        margin-bottom: 0;
+      }
+
+      .projection-count {
+        font-size: 11px;
+        font-weight: 600;
+        color: v.$active-color;
+        background: rgba(v.$active-color, 0.08);
+        padding: 2px 8px;
+        border-radius: 10px;
+        white-space: nowrap;
+      }
+    }
+
+    .projection-columns-actions {
+      display: flex;
+      gap: 12px;
+      margin-bottom: 6px;
+
+      .btn-link {
+        background: none;
+        border: none;
+        padding: 0;
+        font-size: 11px;
+        font-weight: 600;
+        color: v.$active-color;
+        cursor: pointer;
+
+        &:hover {
+          text-decoration: underline;
+        }
+      }
+    }
+
+    .projection-columns-list {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+      overflow-y: auto;
+      flex: 1;
+      min-height: 0;
+    }
+
+    .projection-column-item {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 5px 8px;
+      border: 1px solid v.$gray-200;
+      border-radius: 6px;
+      cursor: pointer;
+      font-size: 12px;
+      transition: all 0.15s ease;
+
+      &:hover {
+        border-color: v.$gray-400;
+      }
+
+      &.selected {
+        background: rgba(v.$active-color, 0.04);
+        border-color: rgba(v.$active-color, 0.3);
+      }
+
+      input[type='checkbox'] {
+        @include w.checkbox;
+        width: 14px;
+        height: 14px;
+        flex-shrink: 0;
+      }
+
+      .col-name {
+        flex: 1;
+        font-weight: 500;
+        color: v.$gray-800;
+        @include m.text-truncate;
+      }
+    }
+
+    .validation-warning {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 8px;
+      background: rgba(v.$status-warning, 0.1);
+      border-left: 3px solid v.$status-warning;
+      border-radius: 8px;
+      font-size: 12px;
+      color: v.$status-warning-dark;
+      margin-top: 8px;
+
+      .material-icons {
+        font-size: 14px;
+      }
+    }
+  }
+
+  // ============================================================================
   // Action Buttons
   // ============================================================================
 

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -677,36 +677,46 @@
 
       h3 {
         margin-bottom: 0;
+
+        // Darker teal accent for the section icon
+        .material-icons {
+          color: v.$status-info;
+        }
       }
 
       .projection-count {
         font-size: 11px;
         font-weight: 600;
-        color: v.$active-color;
-        background: rgba(v.$active-color, 0.08);
+        color: v.$status-info;
+        background: rgba(v.$active-color, 0.14);
         padding: 2px 8px;
         border-radius: 10px;
         white-space: nowrap;
       }
     }
 
-    .projection-columns-actions {
+    .projection-columns-list-header {
       display: flex;
-      gap: 12px;
-      margin-bottom: 6px;
+      align-items: center;
+      gap: 8px;
+      padding: 4px 8px;
+      margin-bottom: 4px;
+      border-bottom: 1px solid v.$gray-200;
 
-      .btn-link {
-        background: none;
-        border: none;
-        padding: 0;
+      .master-checkbox {
+        width: 15px;
+        height: 15px;
+        accent-color: v.$active-color;
+        flex-shrink: 0;
+        cursor: pointer;
+      }
+
+      .master-label {
         font-size: 11px;
         font-weight: 600;
-        color: v.$active-color;
-        cursor: pointer;
-
-        &:hover {
-          text-decoration: underline;
-        }
+        color: v.$gray-500;
+        letter-spacing: 0.3px;
+        text-transform: uppercase;
       }
     }
 
@@ -739,10 +749,16 @@
         border-color: rgba(v.$active-color, 0.3);
       }
 
+      &.excluded .col-name {
+        color: v.$gray-500;
+        text-decoration: line-through;
+      }
+
       input[type='checkbox'] {
         @include w.checkbox;
         width: 14px;
         height: 14px;
+        accent-color: v.$active-color;
         flex-shrink: 0;
       }
 

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
@@ -3,14 +3,21 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { PreprocessingService } from '../../services/preprocessing.service';
 import { WizardStep, WIZARD_STEP } from '../../shared/wizard-step';
-import { ProjectionConfig } from '../../models/column-config';
+import { ColumnConfig, ProjectionConfig } from '../../models/column-config';
 import { ColumnStatistics } from '../../models/column-statistics';
 import { DataType } from '../../models/data-type.enum';
 import { HelpTooltipComponent } from '../../shared/help-tooltip/help-tooltip.component';
 import { HELP_TEXT } from '../../shared/constants/help-text';
 import { STEP_INFO } from '../../shared/constants/step-info';
+import { DataTypeBadgeComponent } from '../../shared/data-type-badge/data-type-badge.component';
 import { COLOR_SCALES, ColorScale, buildGroupedColorScales } from '../../../shared/interfaces/color-scale';
 import { ColorScaleSelectorComponent } from '../../../shared/components/color-scale-selector/color-scale-selector.component';
+
+/** A dataset column paired with its live configuration, used for projection column selection. */
+interface ProjectionColumnState {
+  column: ColumnStatistics;
+  config: ColumnConfig;
+}
 
 /** Describes a tunable parameter for a projection method. */
 interface ProjectionParam {
@@ -54,14 +61,17 @@ interface ProjectionMethodUI {
 @Component({
   selector: 'app-step4-visualization-settings',
   standalone: true,
-  imports: [CommonModule, FormsModule, HelpTooltipComponent, ColorScaleSelectorComponent],
+  imports: [CommonModule, FormsModule, HelpTooltipComponent, DataTypeBadgeComponent, ColorScaleSelectorComponent],
   templateUrl: './step4-visualization-settings.component.html',
   styleUrl: './step4-visualization-settings.component.scss',
   providers: [{ provide: WIZARD_STEP, useExisting: forwardRef(() => Step4VisualizationSettingsComponent) }],
 })
 export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
   readonly primaryLabel = 'Continue to Review';
-  readonly disabledHint = 'Please select 3-12 glyph features to continue.';
+  readonly disabledHint = 'Select at least one projection column and 3-12 glyph features to continue.';
+
+  // Projection column selection (which features feed the dimensionality reduction)
+  projectionColumns: ProjectionColumnState[] = [];
 
   // Color feature selection
   columns: ColumnStatistics[] = [];
@@ -244,6 +254,14 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
         const config = state.columnConfigs.get(col.name);
         return config && config.enabled;
       });
+
+      // Build projection column selection from the enabled columns
+      this.projectionColumns = this.columns
+        .map(col => {
+          const config = state.columnConfigs.get(col.name);
+          return config ? { column: col, config } : null;
+        })
+        .filter((entry): entry is ProjectionColumnState => entry !== null);
     }
 
     // Load color feature and scale
@@ -442,6 +460,37 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
   }
 
   // ============================================================================
+  // Projection Column Selection
+  // ============================================================================
+
+  toggleColumnProjection(columnName: string): void {
+    const entry = this.projectionColumns.find(c => c.column.name === columnName);
+    if (entry) {
+      const newValue = !entry.config.includeInProjection;
+      this.preprocessingService.updateColumnConfig(columnName, { includeInProjection: newValue });
+      // Update local reference to trigger template re-render
+      entry.config.includeInProjection = newValue;
+    }
+  }
+
+  isColumnInProjection(columnName: string): boolean {
+    return this.projectionColumns.find(c => c.column.name === columnName)?.config.includeInProjection ?? false;
+  }
+
+  getProjectionCount(): number {
+    return this.projectionColumns.filter(c => c.config.includeInProjection).length;
+  }
+
+  setAllProjectionColumns(included: boolean): void {
+    for (const entry of this.projectionColumns) {
+      if (entry.config.includeInProjection !== included) {
+        this.preprocessingService.updateColumnConfig(entry.column.name, { includeInProjection: included });
+        entry.config.includeInProjection = included;
+      }
+    }
+  }
+
+  // ============================================================================
   // Projection Configuration
   // ============================================================================
 
@@ -632,7 +681,8 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
       this.selectedGlyphFeatures.length >= this.MIN_GLYPH_FEATURES &&
       this.selectedGlyphFeatures.length <= this.MAX_GLYPH_FEATURES;
     const projectionValid = this.hasEnabledMethod();
-    return glyphValid && projectionValid;
+    const projectionColumnsValid = this.getProjectionCount() > 0;
+    return glyphValid && projectionValid && projectionColumnsValid;
   }
 
   proceed(): void {

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
@@ -490,6 +490,22 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
     }
   }
 
+  /** True when every column is included (master checkbox checked). */
+  allColumnsInProjection(): boolean {
+    return this.projectionColumns.length > 0 && this.getProjectionCount() === this.projectionColumns.length;
+  }
+
+  /** True when only some columns are included (master checkbox indeterminate). */
+  someColumnsInProjection(): boolean {
+    const count = this.getProjectionCount();
+    return count > 0 && count < this.projectionColumns.length;
+  }
+
+  /** Master checkbox: select all unless everything is already selected, in which case clear. */
+  onToggleAllProjection(): void {
+    this.setAllProjectionColumns(!this.allColumnsInProjection());
+  }
+
   // ============================================================================
   // Projection Configuration
   // ============================================================================


### PR DESCRIPTION
## A13 – Schrittlogik klären und neu ordnen

**Was:** Die Auswahl „welche Spalten fließen in die Projektion" wurde aus Schritt 3 entfernt und in Schritt 4 als neue Section **„Projection Options"** platziert (zweispaltig: links Spaltenauswahl, rechts Methodenauswahl). Schritt 3 ist jetzt reine Datenkonfiguration. Die Schrittbeschreibungen in `step-info.ts` wurden geschärft (Schritt 2 = betrachtete Spalten, Schritt 3 = Datenkonfiguration, Schritt 4 = Projektion: Spalten + Methode). Das `includeInProjection`-Flag lag bereits im Service — keine Modell-/Datenflussänderung nötig.

**Manuell testen:**
- **Schritt 3 (Configure Data & Features):** keine „Include in projection"-Checkboxen mehr in den Zeilen oder im Detailpanel, kein „in projection"-Zähler in der Fußzeile; der Weiter-Button ist immer aktiv.
- **Schritt 4 (Visualization Settings)** → Section **„Projection Options"**: links Panel „Projection Columns" (Checkbox-Liste je aktivierter Spalte, Typ-Badge, Zähler z. B. 3/7, „Select all / Clear"); rechts das bestehende Methoden-Grid.
- **Schritt 4:** alle Projektionsspalten abwählen → Warnung erscheint, Weiter-Button deaktiviert. Mindestens eine wählen (bei 3–12 Glyph-Features) → Weiter aktiv.
- **Schritt 5 (Review):** die Anzahl der Projektionsspalten entspricht der Auswahl aus Schritt 4.

**Hinweise:**
- ⚠️ Das DesignSync-Tool war im Agenten-Environment nicht verfügbar — das zweispaltige Layout wurde aus der textuellen Vorgabe umgesetzt und **nicht** gegen `Step4 Projection Options.dc.html` visuell abgeglichen. Bitte Abstände/Wording gegen die Design-Vorlage gegenprüfen.
- Ungenutzte CSS-Klassen in step3 SCSS wurden für einen minimalen Diff belassen (später entfernbar).
- Erwarteter Merge-Konflikt mit A15 und A5 (alle drei bearbeiten Schritt 4).
