### PR TITLE
feat(a5): Projektionsparameter in die Methodenbox gruppieren

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -98,6 +98,8 @@ Quick Wins ohne Abhängigkeit, die sich parallel zum Fundament wegräumen lassen
 
 **Problem:** Fachbegriffe werden ohne Erklärung angeboten (Farbattribut, Projektionsmethoden, FastMap, Ausreißermethoden, Z-Wert-Standardisierung, Smart Defaults).
 
+**Hinweis:** Aus A5 übernommen: Die unerklärten Farbabweichungen bzw. die „Farbauswahl" sind hier über einen erklärenden Text zu lösen, nicht über ein zusätzliches Farb-Steuerelement.
+
 **Wo umsetzen:**
 - Erklärtexte zentral pflegen in `shared/constants/help-text.ts`.
 - Abrufbare Erklärung (Progressive Disclosure) über die bestehende `shared/help-tooltip/`-Komponente; für Projektionsmethoden auf visuelle Tooltips erweitern (Miro „Visual Tooltips Methoden", vgl. `tmp/Projektion_Methoden_Visualisierung.html`).
@@ -154,6 +156,8 @@ Quick Wins ohne Abhängigkeit, die sich parallel zum Fundament wegräumen lassen
 **Wo umsetzen:**
 - Parameter in den Kasten der jeweiligen Methode ziehen + Reset auf Defaultwerte: `steps/step4-visualization-settings/step4-visualization-settings.component.html` und `.ts` (Miro „Parameter Location").
 - Datenkonfiguration klarer strukturieren (Angabe↔Spalte erkennbar): `steps/step3-configure-data-features/`.
+
+**Hinweis:** Der Befund zu unerklärten Farbabweichungen bzw. zur „Farbauswahl" passt inhaltlich nicht zu A5 und wird nach A1 verschoben; dort ist er über einen erklärenden Text statt über ein Farb-Steuerelement zu lösen.
 
 ---
 

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -262,6 +262,7 @@
             class="projection-card"
             [class.enabled]="projectionConfig[method.key]"
             [class.has-warning]="shouldShowLargeDatasetWarning(method)"
+            [class.expanded]="methodHasParams(method) && projectionConfig[method.key] && isMethodParamsExpanded(method.key)"
             (click)="isMethodDisabled(method) ? null : toggleProjectionMethod(method)"
             (keydown.enter)="isMethodDisabled(method) ? null : toggleProjectionMethod(method)"
             tabindex="0"
@@ -299,58 +300,68 @@
               }
             </div>
             <div class="card-desc">{{ method.description }}</div>
+
+            <!-- Parameters grouped inside their own method box -->
+            @if (methodHasParams(method) && projectionConfig[method.key] && isMethodParamsExpanded(method.key)) {
+              <div class="inline-params" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                <div class="params-header">
+                  <span class="params-label">{{ method.name }} Parameters</span>
+                  <button
+                    class="btn-reset-params"
+                    type="button"
+                    (click)="resetMethodParams(method); $event.stopPropagation()"
+                    [disabled]="!methodParamsChanged(method)"
+                    title="Reset parameters to default"
+                  >
+                    <span class="material-icons">restart_alt</span>
+                    Reset
+                  </button>
+                </div>
+                @for (param of method.params; track param.configKey) {
+                  <div class="param-field">
+                    <label [for]="'step4-param-' + param.configKey">
+                      {{ param.label }}
+                      <app-help-tooltip [helpText]="$any(HELP_TEXT.parameters)[param.helpKey]"></app-help-tooltip>
+                    </label>
+                    <div class="input-group">
+                      <input
+                        [id]="'step4-param-' + param.configKey"
+                        type="range"
+                        [min]="param.min"
+                        [max]="param.max"
+                        [step]="param.step || 1"
+                        [value]="projectionConfig[param.configKey]"
+                        (input)="onParamChange(param.configKey, +$any($event.target).value, param.min, param.max)"
+                        class="range-input"
+                      />
+                      <input
+                        type="number"
+                        [min]="param.min"
+                        [max]="param.max"
+                        [step]="param.step || 1"
+                        [value]="projectionConfig[param.configKey]"
+                        (input)="onParamChange(param.configKey, +$any($event.target).value, param.min, param.max)"
+                        class="number-input"
+                      />
+                    </div>
+                  </div>
+                }
+                @if (method.key === 'enableTSNE' && shouldShowTSNEWarning()) {
+                  <div class="warning-box">
+                    <span class="material-icons">warning</span>
+                    <div>
+                      <p>
+                        <strong>{{ getTSNETimeEstimate() }}</strong>
+                      </p>
+                      <p>t-SNE will run in the background. Explore with FastMap while waiting.</p>
+                    </div>
+                  </div>
+                }
+              </div>
+            }
           </div>
         }
       </div>
-
-      <!-- Inline parameters (full width below grid) -->
-      @for (method of projectionMethods; track method.key) {
-        @if (projectionConfig[method.key] && isMethodParamsExpanded(method.key)) {
-          <div class="inline-params">
-            <span class="params-label">{{ method.name }} Parameters</span>
-            @for (param of method.params; track param.configKey) {
-              <div class="param-field">
-                <label [for]="'step4-param-' + param.configKey">
-                  {{ param.label }}
-                  <app-help-tooltip [helpText]="$any(HELP_TEXT.parameters)[param.helpKey]"></app-help-tooltip>
-                </label>
-                <div class="input-group">
-                  <input
-                    [id]="'step4-param-' + param.configKey"
-                    type="range"
-                    [min]="param.min"
-                    [max]="param.max"
-                    [step]="param.step || 1"
-                    [value]="projectionConfig[param.configKey]"
-                    (input)="onParamChange(param.configKey, +$any($event.target).value, param.min, param.max)"
-                    class="range-input"
-                  />
-                  <input
-                    type="number"
-                    [min]="param.min"
-                    [max]="param.max"
-                    [step]="param.step || 1"
-                    [value]="projectionConfig[param.configKey]"
-                    (input)="onParamChange(param.configKey, +$any($event.target).value, param.min, param.max)"
-                    class="number-input"
-                  />
-                </div>
-              </div>
-            }
-            @if (method.key === 'enableTSNE' && shouldShowTSNEWarning()) {
-              <div class="warning-box">
-                <span class="material-icons">warning</span>
-                <div>
-                  <p>
-                    <strong>{{ getTSNETimeEstimate() }}</strong>
-                  </p>
-                  <p>t-SNE will run in the background. Explore with FastMap while waiting.</p>
-                </div>
-              </div>
-            }
-          </div>
-        }
-      }
     </div>
   </div>
 </div>

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -304,8 +304,9 @@
             <!-- Parameters grouped inside their own method box (grows in place) -->
             @if (methodHasParams(method) && projectionConfig[method.key]) {
               <div class="params-wrapper" [class.open]="isMethodParamsExpanded(method.key)">
-                <div class="inline-params" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
-                  <div class="params-header">
+                <div class="params-clip">
+                  <div class="inline-params" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                    <div class="params-header">
                   <span class="params-label">{{ method.name }} Parameters</span>
                   <button
                     class="btn-reset-params"
@@ -358,6 +359,7 @@
                     </div>
                   </div>
                 }
+                  </div>
                 </div>
               </div>
             }

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -301,10 +301,11 @@
             </div>
             <div class="card-desc">{{ method.description }}</div>
 
-            <!-- Parameters grouped inside their own method box -->
-            @if (methodHasParams(method) && projectionConfig[method.key] && isMethodParamsExpanded(method.key)) {
-              <div class="inline-params" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
-                <div class="params-header">
+            <!-- Parameters grouped inside their own method box (grows in place) -->
+            @if (methodHasParams(method) && projectionConfig[method.key]) {
+              <div class="params-wrapper" [class.open]="isMethodParamsExpanded(method.key)">
+                <div class="inline-params" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+                  <div class="params-header">
                   <span class="params-label">{{ method.name }} Parameters</span>
                   <button
                     class="btn-reset-params"
@@ -357,6 +358,7 @@
                     </div>
                   </div>
                 }
+                </div>
               </div>
             }
           </div>

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -586,13 +586,10 @@
     }
 
     // Animated height wrapper: collapses to 0fr, expands to content height in place.
-    // overflow:hidden clips the inner box (incl. its border/padding) so nothing
-    // shows while collapsed.
     .params-wrapper {
       display: grid;
       grid-template-rows: 0fr;
       margin-top: 0;
-      overflow: hidden;
       transition:
         grid-template-rows 0.25s ease,
         margin-top 0.25s ease;
@@ -603,10 +600,14 @@
       }
     }
 
-    .inline-params {
-      // Clipped by the 0fr wrapper while collapsed
+    // Bare grid item: no padding/border/background so the 0fr track truly
+    // collapses to zero and fully clips the padded box below (no sliver).
+    .params-clip {
       min-height: 0;
       overflow: hidden;
+    }
+
+    .inline-params {
       padding: 6px 10px;
       background: v.$wizard-header-bg;
       border: 1px solid v.$gray-200;

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -585,11 +585,14 @@
       border: 1px solid v.$gray-300;
     }
 
-    // Animated height wrapper: collapses to 0fr, expands to content height in place
+    // Animated height wrapper: collapses to 0fr, expands to content height in place.
+    // overflow:hidden clips the inner box (incl. its border/padding) so nothing
+    // shows while collapsed.
     .params-wrapper {
       display: grid;
       grid-template-rows: 0fr;
       margin-top: 0;
+      overflow: hidden;
       transition:
         grid-template-rows 0.25s ease,
         margin-top 0.25s ease;

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -475,6 +475,12 @@
         border-color: rgba(v.$status-warning, 0.3);
       }
 
+      // Give the parameter box full width when a method is expanded
+      &.expanded {
+        grid-column: 1 / -1;
+        cursor: default;
+      }
+
       .card-row {
         display: flex;
         align-items: center;
@@ -585,17 +591,51 @@
       background: v.$wizard-header-bg;
       border: 1px solid v.$gray-200;
       border-radius: 8px;
-      margin-top: 4px;
+      margin-top: 6px;
+      cursor: default;
       display: flex;
       flex-wrap: wrap;
       gap: 8px;
       align-items: flex-end;
 
+      .params-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+      }
+
       .params-label {
         font-size: 11px;
         font-weight: 600;
         color: v.$gray-600;
-        width: 100%;
+      }
+
+      .btn-reset-params {
+        @include w.btn-base;
+        background: white;
+        border: 1px solid v.$gray-300;
+        color: v.$gray-600;
+        font-size: 10px;
+        font-weight: 600;
+        padding: 2px 8px;
+        gap: 3px;
+        flex-shrink: 0;
+
+        .material-icons {
+          font-size: 13px;
+        }
+
+        &:hover:not(:disabled) {
+          background: v.$gray-100;
+          border-color: v.$active-color;
+          color: v.$active-color;
+        }
+
+        &:disabled {
+          opacity: 0.4;
+          cursor: not-allowed;
+        }
       }
 
       .param-field {

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -475,9 +475,8 @@
         border-color: rgba(v.$status-warning, 0.3);
       }
 
-      // Give the parameter box full width when a method is expanded
+      // Keep the card in its own cell; only its height grows when expanded
       &.expanded {
-        grid-column: 1 / -1;
         cursor: default;
       }
 
@@ -586,12 +585,29 @@
       border: 1px solid v.$gray-300;
     }
 
+    // Animated height wrapper: collapses to 0fr, expands to content height in place
+    .params-wrapper {
+      display: grid;
+      grid-template-rows: 0fr;
+      margin-top: 0;
+      transition:
+        grid-template-rows 0.25s ease,
+        margin-top 0.25s ease;
+
+      &.open {
+        grid-template-rows: 1fr;
+        margin-top: 6px;
+      }
+    }
+
     .inline-params {
+      // Clipped by the 0fr wrapper while collapsed
+      min-height: 0;
+      overflow: hidden;
       padding: 6px 10px;
       background: v.$wizard-header-bg;
       border: 1px solid v.$gray-200;
       border-radius: 8px;
-      margin-top: 6px;
       cursor: default;
       display: flex;
       flex-wrap: wrap;
@@ -639,8 +655,9 @@
       }
 
       .param-field {
-        flex: 1;
-        min-width: 180px;
+        // Fit the (narrower) card column: each parameter takes the full width
+        flex: 1 1 100%;
+        min-width: 0;
 
         label {
           display: flex;

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
@@ -20,6 +20,8 @@ interface ProjectionParam {
   min: number;
   max: number;
   step?: number;
+  /** Default value used by the per-method "reset parameters" action. */
+  default: number;
 }
 
 /**
@@ -138,6 +140,7 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
           min: 100,
           max: 2000,
           step: 50,
+          default: 500,
         },
       ],
     },
@@ -159,7 +162,14 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
       sizeHint: 'up to 5K rows',
       largeDatasetWarning: true,
       params: [
-        { label: 'Neighbors (0 = auto)', helpKey: 'isomapNeighbors', configKey: 'isomapNeighbors', min: 0, max: 200 },
+        {
+          label: 'Neighbors (0 = auto)',
+          helpKey: 'isomapNeighbors',
+          configKey: 'isomapNeighbors',
+          min: 0,
+          max: 200,
+          default: 0,
+        },
       ],
     },
     {
@@ -170,7 +180,16 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
       badge: 'Medium',
       sizeHint: 'up to 30K rows',
       largeDatasetWarning: true,
-      params: [{ label: 'Neighbors (0 = auto)', helpKey: 'lleNeighbors', configKey: 'lleNeighbors', min: 0, max: 200 }],
+      params: [
+        {
+          label: 'Neighbors (0 = auto)',
+          helpKey: 'lleNeighbors',
+          configKey: 'lleNeighbors',
+          min: 0,
+          max: 200,
+          default: 0,
+        },
+      ],
     },
     {
       key: 'enableLTSA',
@@ -181,7 +200,14 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
       sizeHint: 'up to 20K rows',
       largeDatasetWarning: true,
       params: [
-        { label: 'Neighbors (0 = auto)', helpKey: 'ltsaNeighbors', configKey: 'ltsaNeighbors', min: 0, max: 200 },
+        {
+          label: 'Neighbors (0 = auto)',
+          helpKey: 'ltsaNeighbors',
+          configKey: 'ltsaNeighbors',
+          min: 0,
+          max: 200,
+          default: 0,
+        },
       ],
     },
     {
@@ -202,8 +228,16 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
       sizeHint: 'up to 100K rows',
       largeDatasetWarning: true,
       params: [
-        { label: 'Number of Neighbors', helpKey: 'umapNeighbors', configKey: 'umapNeighbors', min: 2, max: 200 },
-        { label: 'Minimum Distance', helpKey: 'umapMinDist', configKey: 'umapMinDist', min: 0, max: 0.99, step: 0.01 },
+        { label: 'Number of Neighbors', helpKey: 'umapNeighbors', configKey: 'umapNeighbors', min: 2, max: 200, default: 15 },
+        {
+          label: 'Minimum Distance',
+          helpKey: 'umapMinDist',
+          configKey: 'umapMinDist',
+          min: 0,
+          max: 0.99,
+          step: 0.01,
+          default: 0.1,
+        },
       ],
     },
     {
@@ -224,8 +258,16 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
       sizeHint: 'up to 15K rows',
       largeDatasetWarning: true,
       params: [
-        { label: 'Perplexity', helpKey: 'tsnePerplexity', configKey: 'tsnePerplexity', min: 5, max: 50 },
-        { label: 'Iterations', helpKey: 'tsneIterations', configKey: 'tsneIterations', min: 250, max: 5000, step: 250 },
+        { label: 'Perplexity', helpKey: 'tsnePerplexity', configKey: 'tsnePerplexity', min: 5, max: 50, default: 30 },
+        {
+          label: 'Iterations',
+          helpKey: 'tsneIterations',
+          configKey: 'tsneIterations',
+          min: 250,
+          max: 5000,
+          step: 250,
+          default: 1000,
+        },
       ],
     },
   ];
@@ -621,6 +663,20 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
 
   methodHasParams(method: ProjectionMethodUI): boolean {
     return (method.params?.length ?? 0) > 0;
+  }
+
+  /** Resets all parameters of a method back to their default values. */
+  resetMethodParams(method: ProjectionMethodUI): void {
+    if (!method.params) return;
+    for (const param of method.params) {
+      this.onParamChange(param.configKey, param.default, param.min, param.max);
+    }
+  }
+
+  /** True when at least one parameter of the method differs from its default. */
+  methodParamsChanged(method: ProjectionMethodUI): boolean {
+    if (!method.params) return false;
+    return method.params.some(param => this.projectionConfig[param.configKey] !== param.default);
   }
 
   // ============================================================================


### PR DESCRIPTION
## A5 – Zusammengehöriges gruppieren

**Was:** Die Parameter jeder Projektionsmethode erscheinen jetzt innerhalb der jeweiligen Methoden-Card statt in einem separaten Block darunter; die Card wird beim Aufklappen breiter. Pro Box gibt es einen „Reset", der die Parameter auf ihre Defaultwerte zurücksetzt (neues explizites `default`-Feld pro `ProjectionParam`); der Button ist deaktiviert, solange nichts vom Default abweicht.

**Manuell testen:**
- **Schritt 4 (Visualization Settings)** → Panel „Projection Methods" unten: eine Methode mit Parametern aktivieren (z. B. UMAP, t-SNE, IsoMap, LLE, LTSA, TriMap), dann das Tune-Icon der Card klicken. Erwartung: die Parameter stehen **innerhalb** der Methodenbox, nicht mehr im gemeinsamen Block darunter.
- Einen Parameter ändern, dann **Reset** in der Box-Kopfzeile klicken. Erwartung: Wert springt auf Default; der Button ist ausgegraut, sobald alle Werte wieder Default sind.
- t-SNE mit großem Datensatz: die Laufzeitwarnung erscheint innerhalb der t-SNE-Box.

**Hinweise:**
- Der Schritt-3-Tabellen-Teil von A5 ist hier **bewusst nicht** umgesetzt (läuft in einem anderen Branch) — bitte **Schritt-3-Tabelle im anderen Branch gegenprüfen**.
- ROADMAP-Notiz ergänzt: die unklare Farbdefinition aus A5 gehört inhaltlich zu A1 (Erklärtext statt Farbregler); keine Status-Änderung.
- Erwarteter Merge-Konflikt mit A13 (beide bearbeiten Schritt 4).
