### PR TITLE
feat(a2/a9): Smart-Default-Reset ohne Banner und Power-Shortcuts

### DIFF
--- a/src/app/preprocessing-wizard/services/preprocessing.service.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.ts
@@ -157,6 +157,10 @@ export class PreprocessingService {
   private createDefaultColumnConfig(col: ColumnStatistics): ColumnConfig {
     const capabilities = DATA_TYPE_CONFIG[col.dataType] ?? DATA_TYPE_CONFIG[DataType.Unknown];
 
+    // Smart default: obviously unsuitable columns (mostly missing or constant)
+    // start deselected. Users can re-enable them in Step 2 at any time.
+    const hasIssues = col.missingPercentage > 50 || col.uniqueCount === 1;
+
     return {
       name: col.name,
       originalType: col.dataType,
@@ -168,8 +172,29 @@ export class PreprocessingService {
       missingValueStrategy: MissingValueStrategy.Keep,
       outlierMethod: OutlierMethod.IQR_1_5,
       outlierStrategy: OutlierStrategy.Keep,
-      enabled: true,
-      hasIssues: col.missingPercentage > 50 || col.uniqueCount === 1,
+      enabled: !hasIssues,
+      hasIssues,
+    };
+  }
+
+  /**
+   * Returns the smart-default configuration values for a column, derived from its
+   * original data type (see DATA_TYPE_CONFIG). Used by Step 3 to detect deviations
+   * and offer a reversible "reset to default" control.
+   */
+  public getColumnDefaults(columnName: string): Partial<ColumnConfig> | null {
+    const config = this.currentState.columnConfigs.get(columnName);
+    if (!config) return null;
+
+    const capabilities = DATA_TYPE_CONFIG[config.originalType] ?? DATA_TYPE_CONFIG[DataType.Unknown];
+    return {
+      encodingMethod: capabilities.defaultEncoding,
+      scalingMethod: capabilities.defaultScaling,
+      includeInProjection: capabilities.defaultIncludeInProjection,
+      missingValueStrategy: MissingValueStrategy.Keep,
+      missingValueFillValue: undefined,
+      outlierMethod: OutlierMethod.IQR_1_5,
+      outlierStrategy: OutlierStrategy.Keep,
     };
   }
 
@@ -283,6 +308,22 @@ export class PreprocessingService {
     if (config) {
       this.updateColumnConfig(columnName, { enabled: !config.enabled });
     }
+  }
+
+  /**
+   * Set the enabled state for a specific set of columns in one update. Used by
+   * Step 2 range-select (shift-click) and "select all filtered".
+   */
+  public setColumnsEnabled(columnNames: string[], enabled: boolean): void {
+    const configs = this.currentState.columnConfigs;
+    columnNames.forEach(name => {
+      const config = configs.get(name);
+      if (config) {
+        config.enabled = enabled;
+      }
+    });
+    this.updateState({ columnConfigs: new Map(configs) });
+    this.saveStateToStorage();
   }
 
   public selectAllColumns(): void {

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.html
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.html
@@ -26,6 +26,17 @@
         }
       </div>
 
+      <select [(ngModel)]="filterType" class="type-filter" title="Filter by data type">
+        <option value="all">All Types</option>
+        <option [value]="DataType.Numeric">Numeric</option>
+        <option [value]="DataType.Categorical">Categorical</option>
+        <option [value]="DataType.Text">Text</option>
+        <option [value]="DataType.Date">Date</option>
+        <option [value]="DataType.Boolean">Boolean</option>
+        <option [value]="DataType.Coordinate">Coordinate</option>
+        <option [value]="DataType.ID">ID</option>
+      </select>
+
       <div class="selection-controls">
         <span class="selection-count">{{ enabledCount }} of {{ columns.length }} selected</span>
       </div>
@@ -36,7 +47,7 @@
       @if (filteredColumns.length === 0) {
         <div class="no-results">
           <span class="material-icons">search_off</span>
-          <p>No columns match your search</p>
+          <p>No columns match your search or filter</p>
         </div>
       } @else {
         <table class="columns-table">
@@ -95,7 +106,6 @@
                     type="checkbox"
                     [checked]="isColumnEnabled(column.name)"
                     (click)="onCheckboxClick(i, column.name, $event)"
-                    (change)="toggleColumn(column.name)"
                     [id]="'col-' + column.name"
                     title="Shift-click to select a range"
                   />

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.html
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.html
@@ -13,9 +13,10 @@
       <div class="search-box">
         <span class="material-icons">search</span>
         <input
+          #searchInput
           type="text"
           [(ngModel)]="searchTerm"
-          placeholder="Search by name or type (e.g., 'numeric')..."
+          placeholder="Search by name or type (e.g., 'numeric')... (press / to focus)"
           class="search-input"
         />
         @if (searchTerm) {
@@ -44,10 +45,10 @@
               <th class="col-checkbox">
                 <input
                   type="checkbox"
-                  [checked]="enabledCount === columns.length"
-                  [indeterminate]="enabledCount > 0 && enabledCount < columns.length"
+                  [checked]="allFilteredSelected"
+                  [indeterminate]="someFilteredSelected"
                   (change)="toggleAllColumns()"
-                  title="Toggle all columns"
+                  title="Toggle all visible columns"
                 />
               </th>
               <th class="col-name">Column Name</th>
@@ -82,7 +83,7 @@
             </tr>
           </thead>
           <tbody>
-            @for (column of filteredColumns; track column.name) {
+            @for (column of filteredColumns; track column.name; let i = $index) {
               <tr
                 class="column-row"
                 [class.disabled]="!isColumnEnabled(column.name)"
@@ -93,8 +94,10 @@
                   <input
                     type="checkbox"
                     [checked]="isColumnEnabled(column.name)"
+                    (click)="onCheckboxClick(i, column.name, $event)"
                     (change)="toggleColumn(column.name)"
                     [id]="'col-' + column.name"
+                    title="Shift-click to select a range"
                   />
                 </td>
 

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.html
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.html
@@ -105,7 +105,8 @@
                   <input
                     type="checkbox"
                     [checked]="isColumnEnabled(column.name)"
-                    (click)="onCheckboxClick(i, column.name, $event)"
+                    (click)="onCheckboxClick($event)"
+                    (change)="onCheckboxChange(i, column.name, $event)"
                     [id]="'col-' + column.name"
                     title="Shift-click to select a range"
                   />

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.scss
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.scss
@@ -36,6 +36,13 @@
   position: relative;
 }
 
+.type-filter {
+  @include wizard.select;
+  flex-shrink: 0;
+  font-size: 13px;
+  padding: 8px 28px 8px 10px;
+}
+
 .selection-controls {
   display: flex;
   gap: 12px;

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.ts
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, forwardRef } from '@angular/core';
+import { Component, OnInit, forwardRef, ViewChild, ElementRef, HostListener } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { PreprocessingService } from '../../services/preprocessing.service';
@@ -24,10 +24,15 @@ export class Step2ColumnSelectionComponent implements OnInit, WizardStep {
   readonly primaryLabel = 'Continue to Configure Data & Features';
   readonly disabledHint = 'Please select at least one column to continue';
 
+  @ViewChild('searchInput') searchInput?: ElementRef<HTMLInputElement>;
+
   columns: ColumnStatistics[] = [];
   columnConfigs = new Map<string, ColumnConfig>();
   searchTerm = '';
   columnHistogramCache = new Map<string, HistogramData>();
+
+  // Anchor index (into the currently filtered list) for shift-click range select.
+  private lastCheckedIndex: number | null = null;
 
   // Distribution bars use the single cyan accent (A15) instead of per-type colors.
   // These mirror $active-color (#00bcd4) / $status-info (#00838f); the mini-histogram
@@ -82,22 +87,57 @@ export class Step2ColumnSelectionComponent implements OnInit, WizardStep {
     this.columnConfigs = this.preprocessingService.currentState.columnConfigs;
   }
 
-  toggleAllColumns(): void {
-    if (this.enabledCount === this.columns.length) {
-      this.deselectAll();
-    } else {
-      this.selectAll();
+  /**
+   * Handle a click on a row checkbox. A plain click toggles the single row (the
+   * default checkbox behaviour + the (change) handler). A shift-click extends the
+   * selection: every row between the previous checkbox click and this one (on the
+   * currently filtered list) is set to the state the clicked row is toggling to.
+   */
+  onCheckboxClick(index: number, columnName: string, event: MouseEvent): void {
+    if (event.shiftKey && this.lastCheckedIndex !== null && this.lastCheckedIndex !== index) {
+      // Prevent the default toggle so the range logic fully controls the states.
+      event.preventDefault();
+      const targetState = !this.isColumnEnabled(columnName);
+      const lo = Math.min(this.lastCheckedIndex, index);
+      const hi = Math.max(this.lastCheckedIndex, index);
+      const names = this.filteredColumns.slice(lo, hi + 1).map(col => col.name);
+      this.preprocessingService.setColumnsEnabled(names, targetState);
+      this.columnConfigs = this.preprocessingService.currentState.columnConfigs;
     }
+    // Update anchor for the next shift-click.
+    this.lastCheckedIndex = index;
   }
 
-  selectAll(): void {
-    this.preprocessingService.selectAllColumns();
+  // ── Select-all operates on the currently filtered/visible set (A9) ──────────
+  get filteredEnabledCount(): number {
+    return this.filteredColumns.filter(col => this.isColumnEnabled(col.name)).length;
+  }
+
+  get allFilteredSelected(): boolean {
+    return this.filteredColumns.length > 0 && this.filteredEnabledCount === this.filteredColumns.length;
+  }
+
+  get someFilteredSelected(): boolean {
+    return this.filteredEnabledCount > 0 && this.filteredEnabledCount < this.filteredColumns.length;
+  }
+
+  toggleAllColumns(): void {
+    const names = this.filteredColumns.map(col => col.name);
+    this.preprocessingService.setColumnsEnabled(names, !this.allFilteredSelected);
     this.columnConfigs = this.preprocessingService.currentState.columnConfigs;
   }
 
-  deselectAll(): void {
-    this.preprocessingService.deselectAllColumns();
-    this.columnConfigs = this.preprocessingService.currentState.columnConfigs;
+  /** Focus the column search field when the user presses "/" (unless already typing). */
+  @HostListener('document:keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent): void {
+    if (event.key !== '/') return;
+    const target = event.target as HTMLElement | null;
+    const tag = target?.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target?.isContentEditable) {
+      return;
+    }
+    event.preventDefault();
+    this.searchInput?.nativeElement.focus();
   }
 
   canProceed(): boolean {

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.ts
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.ts
@@ -37,6 +37,8 @@ export class Step2ColumnSelectionComponent implements OnInit, WizardStep {
 
   // Anchor index (into the currently filtered list) for shift-click range select.
   private lastCheckedIndex: number | null = null;
+  // Whether Shift was held during the click that precedes the next (change).
+  private pendingShift = false;
 
   // Distribution bars use the single cyan accent (A15) instead of per-type colors.
   // These mirror $active-color (#00bcd4) / $status-info (#00838f); the mini-histogram
@@ -100,30 +102,36 @@ export class Step2ColumnSelectionComponent implements OnInit, WizardStep {
   }
 
   /**
-   * Single click handler for a row checkbox. It fully owns the checkbox state: the
-   * native toggle is prevented so the one-way [checked] binding stays authoritative
-   * and no second (change) handler can double-toggle the clicked row.
-   *
-   * Plain click toggles that one row. Shift-click sets every row between the
-   * previous checkbox click and this one (inclusive of both ends, on the currently
-   * filtered list) to the state the clicked row is toggling to.
+   * Records whether Shift was held for the click that is about to trigger a
+   * (change). It does NOT toggle anything and does NOT preventDefault — the native
+   * checkbox performs the real toggle, so single selection works and is rendered
+   * correctly via [checked]. The flag is consumed by onCheckboxChange().
    */
-  onCheckboxClick(index: number, columnName: string, event: MouseEvent): void {
-    event.preventDefault();
+  onCheckboxClick(event: MouseEvent): void {
+    this.pendingShift = event.shiftKey;
+  }
 
-    if (event.shiftKey && this.lastCheckedIndex !== null && this.lastCheckedIndex !== index) {
-      const targetState = !this.isColumnEnabled(columnName);
+  /**
+   * Native change handler. The clicked row has already been toggled by the browser;
+   * `newState` is its resulting checked value. We commit that single toggle, and if
+   * Shift was held with a valid anchor, we extend the SAME state across the whole
+   * inclusive range [min(anchor,current) .. max(anchor,current)] on the filtered list.
+   */
+  onCheckboxChange(index: number, columnName: string, event: Event): void {
+    const newState = (event.target as HTMLInputElement).checked;
+
+    if (this.pendingShift && this.lastCheckedIndex !== null && this.lastCheckedIndex !== index) {
       const lo = Math.min(this.lastCheckedIndex, index);
       const hi = Math.max(this.lastCheckedIndex, index);
       const names = this.filteredColumns.slice(lo, hi + 1).map(col => col.name);
-      this.preprocessingService.setColumnsEnabled(names, targetState);
+      this.preprocessingService.setColumnsEnabled(names, newState);
     } else {
-      this.preprocessingService.toggleColumnEnabled(columnName);
+      this.preprocessingService.setColumnsEnabled([columnName], newState);
     }
 
     this.columnConfigs = this.preprocessingService.currentState.columnConfigs;
-    // Update anchor for the next shift-click.
     this.lastCheckedIndex = index;
+    this.pendingShift = false;
   }
 
   // ── Select-all operates on the currently filtered/visible set (A9) ──────────

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.ts
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.ts
@@ -5,7 +5,7 @@ import { PreprocessingService } from '../../services/preprocessing.service';
 import { MiniHistogramComponent } from '../../../shared/components/mini-histogram/mini-histogram.component';
 import { ColumnStatistics, HistogramData } from '../../models/column-statistics';
 import { ColumnConfig } from '../../models/column-config';
-import { getDataTypeColor, getDataTypeBgColor } from '../../models/data-type.enum';
+import { DataType, getDataTypeColor, getDataTypeBgColor } from '../../models/data-type.enum';
 import { HelpTooltipComponent } from '../../shared/help-tooltip/help-tooltip.component';
 import { HELP_TEXT } from '../../shared/constants/help-text';
 import { STEP_INFO } from '../../shared/constants/step-info';
@@ -29,7 +29,11 @@ export class Step2ColumnSelectionComponent implements OnInit, WizardStep {
   columns: ColumnStatistics[] = [];
   columnConfigs = new Map<string, ColumnConfig>();
   searchTerm = '';
+  filterType: DataType | 'all' = 'all';
   columnHistogramCache = new Map<string, HistogramData>();
+
+  // Enum reference for the template's type-filter <select>.
+  DataType = DataType;
 
   // Anchor index (into the currently filtered list) for shift-click range select.
   private lastCheckedIndex: number | null = null;
@@ -61,13 +65,21 @@ export class Step2ColumnSelectionComponent implements OnInit, WizardStep {
   }
 
   get filteredColumns(): ColumnStatistics[] {
-    if (!this.searchTerm) {
-      return this.columns;
+    let cols = this.columns;
+    if (this.filterType !== 'all') {
+      cols = cols.filter(col => col.dataType === this.filterType);
     }
-    const term = this.searchTerm.toLowerCase();
-    return this.columns.filter(
-      col => col.name.toLowerCase().includes(term) || col.dataType.toLowerCase().includes(term)
-    );
+    if (this.searchTerm) {
+      const term = this.searchTerm.toLowerCase();
+      cols = cols.filter(
+        col => col.name.toLowerCase().includes(term) || col.dataType.toLowerCase().includes(term)
+      );
+    }
+    return cols;
+  }
+
+  get hasActiveFilter(): boolean {
+    return !!this.searchTerm || this.filterType !== 'all';
   }
 
   get enabledCount(): number {
@@ -88,22 +100,28 @@ export class Step2ColumnSelectionComponent implements OnInit, WizardStep {
   }
 
   /**
-   * Handle a click on a row checkbox. A plain click toggles the single row (the
-   * default checkbox behaviour + the (change) handler). A shift-click extends the
-   * selection: every row between the previous checkbox click and this one (on the
-   * currently filtered list) is set to the state the clicked row is toggling to.
+   * Single click handler for a row checkbox. It fully owns the checkbox state: the
+   * native toggle is prevented so the one-way [checked] binding stays authoritative
+   * and no second (change) handler can double-toggle the clicked row.
+   *
+   * Plain click toggles that one row. Shift-click sets every row between the
+   * previous checkbox click and this one (inclusive of both ends, on the currently
+   * filtered list) to the state the clicked row is toggling to.
    */
   onCheckboxClick(index: number, columnName: string, event: MouseEvent): void {
+    event.preventDefault();
+
     if (event.shiftKey && this.lastCheckedIndex !== null && this.lastCheckedIndex !== index) {
-      // Prevent the default toggle so the range logic fully controls the states.
-      event.preventDefault();
       const targetState = !this.isColumnEnabled(columnName);
       const lo = Math.min(this.lastCheckedIndex, index);
       const hi = Math.max(this.lastCheckedIndex, index);
       const names = this.filteredColumns.slice(lo, hi + 1).map(col => col.name);
       this.preprocessingService.setColumnsEnabled(names, targetState);
-      this.columnConfigs = this.preprocessingService.currentState.columnConfigs;
+    } else {
+      this.preprocessingService.toggleColumnEnabled(columnName);
     }
+
+    this.columnConfigs = this.preprocessingService.currentState.columnConfigs;
     // Update anchor for the next shift-click.
     this.lastCheckedIndex = index;
   }

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.html
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.html
@@ -207,17 +207,17 @@
                     <div class="section-header">
                       <span class="section-label">Encoding</span>
                       <app-help-tooltip [helpText]="HELP_TEXT.tableHeaders.encoding" position="bottom"></app-help-tooltip>
-                      @if (isEncodingModified(selectedColumn)) {
-                        <button
-                          class="btn-reset-field"
-                          type="button"
-                          (click)="resetEncoding(selectedColumn)"
-                          title="Reset encoding to smart default"
-                        >
-                          <span class="material-icons">restart_alt</span>
-                          Reset
-                        </button>
-                      }
+                      <button
+                        class="btn-reset-field"
+                        type="button"
+                        [class.is-hidden]="!isEncodingModified(selectedColumn)"
+                        [disabled]="!isEncodingModified(selectedColumn)"
+                        (click)="resetEncoding(selectedColumn)"
+                        title="Reset encoding to smart default"
+                      >
+                        <span class="material-icons">restart_alt</span>
+                        Reset
+                      </button>
                     </div>
                     <select
                       class="config-select"
@@ -237,17 +237,17 @@
                     <div class="section-header">
                       <span class="section-label">Scaling</span>
                       <app-help-tooltip [helpText]="HELP_TEXT.tableHeaders.scaling" position="bottom"></app-help-tooltip>
-                      @if (isScalingModified(selectedColumn)) {
-                        <button
-                          class="btn-reset-field"
-                          type="button"
-                          (click)="resetScaling(selectedColumn)"
-                          title="Reset scaling to smart default"
-                        >
-                          <span class="material-icons">restart_alt</span>
-                          Reset
-                        </button>
-                      }
+                      <button
+                        class="btn-reset-field"
+                        type="button"
+                        [class.is-hidden]="!isScalingModified(selectedColumn)"
+                        [disabled]="!isScalingModified(selectedColumn)"
+                        (click)="resetScaling(selectedColumn)"
+                        title="Reset scaling to smart default"
+                      >
+                        <span class="material-icons">restart_alt</span>
+                        Reset
+                      </button>
                     </div>
                     <select
                       class="config-select"
@@ -275,17 +275,17 @@
                         [helpText]="HELP_TEXT.tableHeaders.missingValues"
                         position="bottom"
                       ></app-help-tooltip>
-                      @if (isMissingModified(selectedColumn)) {
-                        <button
-                          class="btn-reset-field"
-                          type="button"
-                          (click)="resetMissing(selectedColumn)"
-                          title="Reset missing-value handling to smart default"
-                        >
-                          <span class="material-icons">restart_alt</span>
-                          Reset
-                        </button>
-                      }
+                      <button
+                        class="btn-reset-field"
+                        type="button"
+                        [class.is-hidden]="!isMissingModified(selectedColumn)"
+                        [disabled]="!isMissingModified(selectedColumn)"
+                        (click)="resetMissing(selectedColumn)"
+                        title="Reset missing-value handling to smart default"
+                      >
+                        <span class="material-icons">restart_alt</span>
+                        Reset
+                      </button>
                     </div>
                     <select
                       class="config-select"
@@ -321,22 +321,23 @@
                         <span class="section-count">{{ selectedColumn.outlierCount }} detected</span>
                       }
                       <app-help-tooltip [helpText]="HELP_TEXT.tableHeaders.outliers" position="bottom"></app-help-tooltip>
-                      @if (isOutlierModified(selectedColumn)) {
-                        <button
-                          class="btn-reset-field"
-                          type="button"
-                          (click)="resetOutliers(selectedColumn)"
-                          [disabled]="selectedColumn.isLoadingOutliers"
-                          title="Reset outlier handling to smart default"
-                        >
-                          <span class="material-icons">restart_alt</span>
-                          Reset
-                        </button>
-                      }
                     </div>
                     <div class="outlier-controls">
                       <div class="control-group">
-                        <label for="step3-outlier-method">Detection Method</label>
+                        <div class="cg-label-row">
+                          <label for="step3-outlier-method">Detection Method</label>
+                          <button
+                            class="btn-reset-field"
+                            type="button"
+                            [class.is-hidden]="!isOutlierMethodModified(selectedColumn)"
+                            [disabled]="!isOutlierMethodModified(selectedColumn) || selectedColumn.isLoadingOutliers"
+                            (click)="resetOutlierMethod(selectedColumn)"
+                            title="Reset detection method to smart default"
+                          >
+                            <span class="material-icons">restart_alt</span>
+                            Reset
+                          </button>
+                        </div>
                         <select
                           id="step3-outlier-method"
                           class="config-select"
@@ -350,7 +351,20 @@
                         </select>
                       </div>
                       <div class="control-group">
-                        <label for="step3-outlier-strategy">Strategy</label>
+                        <div class="cg-label-row">
+                          <label for="step3-outlier-strategy">Strategy</label>
+                          <button
+                            class="btn-reset-field"
+                            type="button"
+                            [class.is-hidden]="!isOutlierStrategyModified(selectedColumn)"
+                            [disabled]="!isOutlierStrategyModified(selectedColumn) || selectedColumn.isLoadingOutliers"
+                            (click)="resetOutlierStrategy(selectedColumn)"
+                            title="Reset strategy to smart default"
+                          >
+                            <span class="material-icons">restart_alt</span>
+                            Reset
+                          </button>
+                        </div>
                         <select
                           id="step3-outlier-strategy"
                           class="config-select"
@@ -370,16 +384,63 @@
                 <!-- Bulk apply to same-type columns (A9) -->
                 @if (getSameTypeColumns(selectedColumn).length > 0) {
                   <div class="bulk-apply">
-                    <button
-                      class="btn-bulk-apply"
-                      type="button"
-                      (click)="applyToSameType(selectedColumn)"
-                      title="Copy these settings to every other column of the same type"
-                    >
-                      <span class="material-icons">library_add_check</span>
-                      Apply to all {{ getSameTypeColumns(selectedColumn).length }}
-                      {{ getTypeLabel(selectedColumn.column.dataType) }} columns
-                    </button>
+                    <div class="bulk-actions">
+                      <button
+                        class="btn-bulk-apply"
+                        type="button"
+                        (click)="applyToSameType(selectedColumn)"
+                        title="Copy these settings to every other column of the same type"
+                      >
+                        <span class="material-icons">library_add_check</span>
+                        Apply to {{ getSameTypeColumns(selectedColumn).length }} other
+                        {{ getTypeLabel(selectedColumn.column.dataType) }} columns
+                      </button>
+                      <button
+                        class="btn-bulk-toggle"
+                        type="button"
+                        (click)="toggleBulkTargets()"
+                        [attr.aria-expanded]="showBulkTargets"
+                      >
+                        <span class="material-icons">{{ showBulkTargets ? 'expand_less' : 'expand_more' }}</span>
+                        Which columns?
+                      </button>
+                    </div>
+
+                    @if (showBulkTargets) {
+                      <div class="bulk-targets">
+                        <span class="bulk-targets-hint">
+                          Copies <em>{{ getBulkSettingsSummary(selectedColumn) }}</em> to:
+                        </span>
+                        <ul>
+                          @for (target of getSameTypeColumns(selectedColumn); track target.column.name) {
+                            <li>
+                              <span class="material-icons">chevron_right</span>
+                              <span class="target-name">{{ target.column.name }}</span>
+                              @if (target.column.missingCount === 0) {
+                                <span class="target-note">no missing values</span>
+                              }
+                            </li>
+                          }
+                        </ul>
+                      </div>
+                    }
+
+                    @if (bulkApplyResult) {
+                      <div class="bulk-result" role="status">
+                        <span class="material-icons">check_circle</span>
+                        <div class="bulk-result-body">
+                          <strong
+                            >Applied to {{ bulkApplyResult.columnNames.length }}
+                            {{ bulkApplyResult.typeLabel }} column(s)</strong
+                          >
+                          <span class="bulk-result-settings">{{ bulkApplyResult.settingsSummary }}</span>
+                          <span class="bulk-result-cols">{{ bulkApplyResult.columnNames.join(', ') }}</span>
+                        </div>
+                        <button class="bulk-result-close" type="button" (click)="dismissBulkResult()" title="Dismiss">
+                          <span class="material-icons">close</span>
+                        </button>
+                      </div>
+                    }
                   </div>
                 }
               </div>

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.html
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.html
@@ -6,20 +6,6 @@
         {{ error }}
       </div>
     } @else {
-      <!-- Dismissible Info Box -->
-      @if (showInfoBox) {
-        <div class="info-box">
-          <span class="material-icons">auto_fix_high</span>
-          <span
-            ><strong>Smart defaults applied</strong> — review and adjust settings as needed.
-            <app-help-tooltip [helpText]="HELP_TEXT.general.smartDefaults"></app-help-tooltip>
-          </span>
-          <button class="dismiss-btn" (click)="showInfoBox = false">
-            <span class="material-icons">close</span>
-          </button>
-        </div>
-      }
-
       <!-- Master rail + recessed detail well -->
       <div class="config-shell">
         <!-- LEFT RAIL: dataset columns -->
@@ -30,10 +16,11 @@
             <div class="search-box">
               <span class="material-icons">search</span>
               <input
+                #railSearchInput
                 type="text"
                 [(ngModel)]="filterText"
                 (ngModelChange)="onFilterChange()"
-                placeholder="Search columns…"
+                placeholder="Search columns… (press /)"
                 class="search-input"
               />
               @if (filterText) {
@@ -122,6 +109,17 @@
                 <div class="card-title-row">
                   <h3 [title]="selectedColumn.column.name">{{ selectedColumn.column.name }}</h3>
                   <span class="type-pill">{{ getTypeLabel(selectedColumn.column.dataType) }}</span>
+                  @if (isColumnModified(selectedColumn)) {
+                    <button
+                      class="btn-reset-column"
+                      type="button"
+                      (click)="resetColumnToDefault(selectedColumn)"
+                      title="Reset all settings of this column to smart defaults"
+                    >
+                      <span class="material-icons">restart_alt</span>
+                      Reset to defaults
+                    </button>
+                  }
                 </div>
               </div>
 
@@ -209,6 +207,17 @@
                     <div class="section-header">
                       <span class="section-label">Encoding</span>
                       <app-help-tooltip [helpText]="HELP_TEXT.tableHeaders.encoding" position="bottom"></app-help-tooltip>
+                      @if (isEncodingModified(selectedColumn)) {
+                        <button
+                          class="btn-reset-field"
+                          type="button"
+                          (click)="resetEncoding(selectedColumn)"
+                          title="Reset encoding to smart default"
+                        >
+                          <span class="material-icons">restart_alt</span>
+                          Reset
+                        </button>
+                      }
                     </div>
                     <select
                       class="config-select"
@@ -228,6 +237,17 @@
                     <div class="section-header">
                       <span class="section-label">Scaling</span>
                       <app-help-tooltip [helpText]="HELP_TEXT.tableHeaders.scaling" position="bottom"></app-help-tooltip>
+                      @if (isScalingModified(selectedColumn)) {
+                        <button
+                          class="btn-reset-field"
+                          type="button"
+                          (click)="resetScaling(selectedColumn)"
+                          title="Reset scaling to smart default"
+                        >
+                          <span class="material-icons">restart_alt</span>
+                          Reset
+                        </button>
+                      }
                     </div>
                     <select
                       class="config-select"
@@ -255,6 +275,17 @@
                         [helpText]="HELP_TEXT.tableHeaders.missingValues"
                         position="bottom"
                       ></app-help-tooltip>
+                      @if (isMissingModified(selectedColumn)) {
+                        <button
+                          class="btn-reset-field"
+                          type="button"
+                          (click)="resetMissing(selectedColumn)"
+                          title="Reset missing-value handling to smart default"
+                        >
+                          <span class="material-icons">restart_alt</span>
+                          Reset
+                        </button>
+                      }
                     </div>
                     <select
                       class="config-select"
@@ -290,6 +321,18 @@
                         <span class="section-count">{{ selectedColumn.outlierCount }} detected</span>
                       }
                       <app-help-tooltip [helpText]="HELP_TEXT.tableHeaders.outliers" position="bottom"></app-help-tooltip>
+                      @if (isOutlierModified(selectedColumn)) {
+                        <button
+                          class="btn-reset-field"
+                          type="button"
+                          (click)="resetOutliers(selectedColumn)"
+                          [disabled]="selectedColumn.isLoadingOutliers"
+                          title="Reset outlier handling to smart default"
+                        >
+                          <span class="material-icons">restart_alt</span>
+                          Reset
+                        </button>
+                      }
                     </div>
                     <div class="outlier-controls">
                       <div class="control-group">
@@ -321,6 +364,22 @@
                         </select>
                       </div>
                     </div>
+                  </div>
+                }
+
+                <!-- Bulk apply to same-type columns (A9) -->
+                @if (getSameTypeColumns(selectedColumn).length > 0) {
+                  <div class="bulk-apply">
+                    <button
+                      class="btn-bulk-apply"
+                      type="button"
+                      (click)="applyToSameType(selectedColumn)"
+                      title="Copy these settings to every other column of the same type"
+                    >
+                      <span class="material-icons">library_add_check</span>
+                      Apply to all {{ getSameTypeColumns(selectedColumn).length }}
+                      {{ getTypeLabel(selectedColumn.column.dataType) }} columns
+                    </button>
                   </div>
                 }
               </div>

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.scss
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.scss
@@ -14,31 +14,6 @@
     @include w.step-header;
   }
 
-  .info-box {
-    @include w.info-box;
-    position: relative;
-
-    .dismiss-btn {
-      position: absolute;
-      top: 8px;
-      right: 8px;
-      background: none;
-      border: none;
-      cursor: pointer;
-      color: v.$gray-500;
-      padding: 2px;
-      display: flex;
-
-      &:hover {
-        color: v.$gray-800;
-      }
-
-      .material-icons {
-        font-size: 16px;
-      }
-    }
-  }
-
   .error-message {
     @include w.message-error;
   }
@@ -294,6 +269,29 @@
         text-transform: uppercase;
         color: v.$gray-500;
       }
+
+      .btn-reset-column {
+        @include w.btn-base;
+        margin-left: auto;
+        flex-shrink: 0;
+        background: white;
+        border: 1px solid v.$gray-300;
+        color: v.$gray-600;
+        font-size: 11px;
+        font-weight: 600;
+        padding: 3px 10px;
+        gap: 4px;
+
+        .material-icons {
+          font-size: 14px;
+        }
+
+        &:hover {
+          background: v.$gray-100;
+          border-color: v.$active-color;
+          color: v.$active-color;
+        }
+      }
     }
   }
 
@@ -400,6 +398,68 @@
         &.spinning {
           animation: spin 1s linear infinite;
         }
+      }
+    }
+
+    // Per-setting reset, only rendered when the value deviates from the smart
+    // default (A2). Mirrors the reset control in Step 4's projection params.
+    .btn-reset-field {
+      @include w.btn-base;
+      margin-left: auto;
+      flex-shrink: 0;
+      background: white;
+      border: 1px solid v.$gray-300;
+      color: v.$gray-600;
+      font-size: 10px;
+      font-weight: 600;
+      padding: 2px 8px;
+      gap: 3px;
+
+      .material-icons {
+        font-size: 13px;
+      }
+
+      &:hover:not(:disabled) {
+        background: v.$gray-100;
+        border-color: v.$active-color;
+        color: v.$active-color;
+      }
+
+      &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+    }
+
+    // When a warning count already claims the right edge, sit next to it.
+    .section-count + .btn-reset-field {
+      margin-left: 4px;
+    }
+  }
+
+  .bulk-apply {
+    padding-top: 14px;
+    margin-top: 2px;
+
+    .btn-bulk-apply {
+      @include w.btn-base;
+      width: 100%;
+      justify-content: center;
+      background: rgba(v.$active-color, 0.08);
+      border: 1px solid rgba(v.$active-color, 0.5);
+      color: v.$status-info;
+      font-size: 12px;
+      font-weight: 600;
+      padding: 8px 12px;
+      gap: 6px;
+
+      .material-icons {
+        font-size: 16px;
+      }
+
+      &:hover {
+        background: rgba(v.$active-color, 0.14);
+        border-color: v.$active-color;
       }
     }
   }

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.scss
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.scss
@@ -429,6 +429,13 @@
         opacity: 0.4;
         cursor: not-allowed;
       }
+
+      // Reserve the button's space even when inactive so revealing it never
+      // shifts the surrounding label / missing-count (review point 2).
+      &.is-hidden {
+        visibility: hidden;
+        pointer-events: none;
+      }
     }
 
     // When a warning count already claims the right edge, sit next to it.
@@ -437,20 +444,75 @@
     }
   }
 
+  // Label row inside an outlier control-group: label on the left, its own inline
+  // reset on the right (space reserved via .is-hidden — no layout shift).
+  .cg-label-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+
+    label {
+      margin: 0;
+    }
+
+    .btn-reset-field {
+      @include w.btn-base;
+      margin-left: auto;
+      flex-shrink: 0;
+      background: white;
+      border: 1px solid v.$gray-300;
+      color: v.$gray-600;
+      font-size: 10px;
+      font-weight: 600;
+      padding: 1px 6px;
+      gap: 3px;
+
+      .material-icons {
+        font-size: 12px;
+      }
+
+      &:hover:not(:disabled) {
+        background: v.$gray-100;
+        border-color: v.$active-color;
+        color: v.$active-color;
+      }
+
+      &:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+      }
+
+      &.is-hidden {
+        visibility: hidden;
+        pointer-events: none;
+      }
+    }
+  }
+
   .bulk-apply {
     padding-top: 14px;
     margin-top: 2px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
 
+    .bulk-actions {
+      display: flex;
+      align-items: center;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    // Compact, content-width button (review point 3b — no full-width whitespace).
     .btn-bulk-apply {
       @include w.btn-base;
-      width: 100%;
-      justify-content: center;
+      align-self: flex-start;
       background: rgba(v.$active-color, 0.08);
       border: 1px solid rgba(v.$active-color, 0.5);
       color: v.$status-info;
       font-size: 12px;
       font-weight: 600;
-      padding: 8px 12px;
+      padding: 6px 10px;
       gap: 6px;
 
       .material-icons {
@@ -460,6 +522,130 @@
       &:hover {
         background: rgba(v.$active-color, 0.14);
         border-color: v.$active-color;
+      }
+    }
+
+    .btn-bulk-toggle {
+      @include w.btn-text;
+      font-size: 11px;
+      padding: 4px 6px;
+      gap: 3px;
+
+      .material-icons {
+        font-size: 15px;
+      }
+    }
+
+    // Progressive-disclosure list of affected columns (review point 3a).
+    .bulk-targets {
+      background: v.$wizard-header-bg;
+      border: 1px solid v.$gray-200;
+      border-radius: 4px;
+      padding: 8px 10px;
+
+      .bulk-targets-hint {
+        display: block;
+        font-size: 11px;
+        color: v.$gray-600;
+        margin-bottom: 6px;
+
+        em {
+          font-style: normal;
+          font-weight: 600;
+          color: v.$status-info;
+        }
+      }
+
+      ul {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+      }
+
+      li {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        font-size: 12px;
+        color: v.$gray-800;
+
+        .material-icons {
+          font-size: 14px;
+          color: v.$gray-500;
+        }
+
+        .target-name {
+          font-weight: 500;
+        }
+
+        .target-note {
+          font-size: 10px;
+          color: v.$gray-500;
+          font-style: italic;
+        }
+      }
+    }
+
+    // Post-apply confirmation (review point 5).
+    .bulk-result {
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      background: rgba(v.$active-color, 0.08);
+      border: 1px solid rgba(v.$active-color, 0.5);
+      border-radius: 4px;
+      padding: 8px 10px;
+
+      > .material-icons {
+        font-size: 18px;
+        color: v.$status-info;
+        flex-shrink: 0;
+      }
+
+      .bulk-result-body {
+        flex: 1;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+
+        strong {
+          font-size: 12px;
+          color: v.$gray-800;
+        }
+
+        .bulk-result-settings {
+          font-size: 11px;
+          color: v.$status-info;
+          font-weight: 600;
+        }
+
+        .bulk-result-cols {
+          font-size: 11px;
+          color: v.$gray-600;
+          word-break: break-word;
+        }
+      }
+
+      .bulk-result-close {
+        background: none;
+        border: none;
+        cursor: pointer;
+        color: v.$gray-500;
+        padding: 0;
+        display: flex;
+        flex-shrink: 0;
+
+        &:hover {
+          color: v.$gray-800;
+        }
+
+        .material-icons {
+          font-size: 16px;
+        }
       }
     }
   }

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.ts
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, forwardRef } from '@angular/core';
+import { Component, OnInit, forwardRef, ViewChild, ElementRef, HostListener } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PreprocessingService } from '../../services/preprocessing.service';
 import { WizardStep, WIZARD_STEP } from '../../shared/wizard-step';
@@ -39,14 +39,13 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
   readonly primaryLabel = 'Continue to Visualization Settings';
   readonly disabledHint = '';
 
+  @ViewChild('railSearchInput') railSearchInput?: ElementRef<HTMLInputElement>;
+
   columns: ColumnConfigState[] = [];
   filteredColumns: ColumnConfigState[] = [];
 
   // Selection state for list+detail panel
   selectedColumnName: string | null = null;
-
-  // UI state
-  showInfoBox = true;
 
   // Duplicate handling
   duplicateCount = 0;
@@ -322,6 +321,140 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
 
   selectColumn(name: string): void {
     this.selectedColumnName = name;
+  }
+
+  // ============================================================================
+  // A2 – Smart defaults: deviation detection + reversible reset
+  // ============================================================================
+
+  /** Smart-default values for a column, derived from its data type. */
+  private getDefaults(colState: ColumnConfigState): Partial<ColumnConfig> {
+    return this.preprocessingService.getColumnDefaults(colState.column.name) ?? {};
+  }
+
+  isEncodingModified(colState: ColumnConfigState): boolean {
+    return colState.config.encodingMethod !== this.getDefaults(colState).encodingMethod;
+  }
+
+  isScalingModified(colState: ColumnConfigState): boolean {
+    return colState.config.scalingMethod !== this.getDefaults(colState).scalingMethod;
+  }
+
+  isMissingModified(colState: ColumnConfigState): boolean {
+    const def = this.getDefaults(colState);
+    return (
+      colState.config.missingValueStrategy !== def.missingValueStrategy ||
+      (colState.config.missingValueStrategy === MissingValueStrategy.FillValue &&
+        !!colState.config.missingValueFillValue)
+    );
+  }
+
+  isOutlierModified(colState: ColumnConfigState): boolean {
+    const def = this.getDefaults(colState);
+    return (
+      colState.config.outlierMethod !== def.outlierMethod ||
+      colState.config.outlierStrategy !== def.outlierStrategy
+    );
+  }
+
+  /** True when any setting of the column deviates from its smart default. */
+  isColumnModified(colState: ColumnConfigState): boolean {
+    return (
+      this.isEncodingModified(colState) ||
+      this.isScalingModified(colState) ||
+      this.isMissingModified(colState) ||
+      this.isOutlierModified(colState)
+    );
+  }
+
+  resetEncoding(colState: ColumnConfigState): void {
+    const method = this.getDefaults(colState).encodingMethod;
+    if (method === undefined) return;
+    colState.config.encodingMethod = method;
+    this.preprocessingService.updateColumnConfig(colState.column.name, { encodingMethod: method });
+  }
+
+  resetScaling(colState: ColumnConfigState): void {
+    const method = this.getDefaults(colState).scalingMethod;
+    if (method === undefined) return;
+    colState.config.scalingMethod = method;
+    this.preprocessingService.updateColumnConfig(colState.column.name, { scalingMethod: method });
+  }
+
+  resetMissing(colState: ColumnConfigState): void {
+    const strategy = this.getDefaults(colState).missingValueStrategy;
+    if (strategy === undefined) return;
+    colState.config.missingValueStrategy = strategy;
+    colState.config.missingValueFillValue = undefined;
+    this.preprocessingService.updateColumnConfig(colState.column.name, {
+      missingValueStrategy: strategy,
+      missingValueFillValue: undefined,
+    });
+  }
+
+  async resetOutliers(colState: ColumnConfigState): Promise<void> {
+    const def = this.getDefaults(colState);
+    if (def.outlierMethod === undefined || def.outlierStrategy === undefined) return;
+    colState.config.outlierMethod = def.outlierMethod;
+    colState.config.outlierStrategy = def.outlierStrategy;
+    this.preprocessingService.updateColumnConfig(colState.column.name, {
+      outlierMethod: def.outlierMethod,
+      outlierStrategy: def.outlierStrategy,
+    });
+    await this.detectOutliersForColumn(colState);
+  }
+
+  /** Reset every setting of the selected column back to its smart default. */
+  resetColumnToDefault(colState: ColumnConfigState): void {
+    this.resetEncoding(colState);
+    this.resetScaling(colState);
+    this.resetMissing(colState);
+    void this.resetOutliers(colState);
+  }
+
+  // ============================================================================
+  // A9 – Bulk apply settings to all columns of the same type
+  // ============================================================================
+
+  getSameTypeColumns(colState: ColumnConfigState): ColumnConfigState[] {
+    return this.columns.filter(
+      c => c.column.dataType === colState.column.dataType && c.column.name !== colState.column.name
+    );
+  }
+
+  applyToSameType(source: ColumnConfigState): void {
+    const targets = this.getSameTypeColumns(source);
+    if (targets.length === 0) return;
+
+    const updates: Partial<ColumnConfig> = {
+      encodingMethod: source.config.encodingMethod,
+      scalingMethod: source.config.scalingMethod,
+      missingValueStrategy: source.config.missingValueStrategy,
+      missingValueFillValue: source.config.missingValueFillValue,
+      outlierMethod: source.config.outlierMethod,
+      outlierStrategy: source.config.outlierStrategy,
+    };
+
+    for (const target of targets) {
+      Object.assign(target.config, updates);
+      this.preprocessingService.updateColumnConfig(target.column.name, updates);
+      if (this.shouldShowOutliers(target)) {
+        void this.detectOutliersForColumn(target);
+      }
+    }
+  }
+
+  /** Focus the column search field when the user presses "/" (unless already typing). */
+  @HostListener('document:keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent): void {
+    if (event.key !== '/') return;
+    const target = event.target as HTMLElement | null;
+    const tag = target?.tagName;
+    if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || target?.isContentEditable) {
+      return;
+    }
+    event.preventDefault();
+    this.railSearchInput?.nativeElement.focus();
   }
 
   getConfigSummary(colState: ColumnConfigState): string {

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.ts
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.ts
@@ -47,6 +47,15 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
   // Selection state for list+detail panel
   selectedColumnName: string | null = null;
 
+  // Bulk-apply (A9) UI state: progressive-disclosure list + post-apply confirmation.
+  showBulkTargets = false;
+  bulkApplyResult: {
+    sourceName: string;
+    typeLabel: string;
+    columnNames: string[];
+    settingsSummary: string;
+  } | null = null;
+
   // Duplicate handling
   duplicateCount = 0;
   duplicatePercentage = 0;
@@ -144,8 +153,11 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- guaranteed by the .filter() which checks columnConfigs.get(col.name)?.enabled
         const config = state.columnConfigs.get(col.name)!;
         return {
+          // Clone the config so each row owns an independent object. Sharing the
+          // service-map reference here let a single-column edit appear to leak into
+          // other rows; every change is still written back via updateColumnConfig.
           column: col,
-          config: config,
+          config: { ...config },
           outlierCount: config.outlierCount,
           isLoadingOutliers: false,
         };
@@ -268,10 +280,19 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
 
   onEncodingChange(columnName: string, method: EncodingMethod): void {
     this.preprocessingService.updateColumnConfig(columnName, { encodingMethod: method });
+    // Mirror into local state so the deviation check (and its inline reset) update.
+    const colState = this.columns.find(c => c.column.name === columnName);
+    if (colState) {
+      colState.config.encodingMethod = method;
+    }
   }
 
   onScalingChange(columnName: string, method: ScalingMethod): void {
     this.preprocessingService.updateColumnConfig(columnName, { scalingMethod: method });
+    const colState = this.columns.find(c => c.column.name === columnName);
+    if (colState) {
+      colState.config.scalingMethod = method;
+    }
   }
 
   onMissingStrategyChange(columnName: string, strategy: MissingValueStrategy): void {
@@ -289,6 +310,10 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
     this.preprocessingService.updateColumnConfig(columnName, {
       missingValueFillValue: fillValue,
     });
+    const colState = this.columns.find(c => c.column.name === columnName);
+    if (colState) {
+      colState.config.missingValueFillValue = fillValue;
+    }
   }
 
   async onOutlierMethodChange(columnName: string, method: OutlierMethod): Promise<void> {
@@ -298,6 +323,7 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
 
     const colState = this.columns.find(c => c.column.name === columnName);
     if (colState) {
+      colState.config.outlierMethod = method;
       await this.detectOutliersForColumn(colState);
     }
   }
@@ -306,6 +332,10 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
     this.preprocessingService.updateColumnConfig(columnName, {
       outlierStrategy: strategy,
     });
+    const colState = this.columns.find(c => c.column.name === columnName);
+    if (colState) {
+      colState.config.outlierStrategy = strategy;
+    }
   }
 
   toggleRemoveDuplicates(): void {
@@ -321,6 +351,9 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
 
   selectColumn(name: string): void {
     this.selectedColumnName = name;
+    // Collapse per-column bulk UI when switching columns.
+    this.showBulkTargets = false;
+    this.bulkApplyResult = null;
   }
 
   // ============================================================================
@@ -349,12 +382,16 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
     );
   }
 
+  isOutlierMethodModified(colState: ColumnConfigState): boolean {
+    return colState.config.outlierMethod !== this.getDefaults(colState).outlierMethod;
+  }
+
+  isOutlierStrategyModified(colState: ColumnConfigState): boolean {
+    return colState.config.outlierStrategy !== this.getDefaults(colState).outlierStrategy;
+  }
+
   isOutlierModified(colState: ColumnConfigState): boolean {
-    const def = this.getDefaults(colState);
-    return (
-      colState.config.outlierMethod !== def.outlierMethod ||
-      colState.config.outlierStrategy !== def.outlierStrategy
-    );
+    return this.isOutlierMethodModified(colState) || this.isOutlierStrategyModified(colState);
   }
 
   /** True when any setting of the column deviates from its smart default. */
@@ -392,16 +429,24 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
     });
   }
 
-  async resetOutliers(colState: ColumnConfigState): Promise<void> {
-    const def = this.getDefaults(colState);
-    if (def.outlierMethod === undefined || def.outlierStrategy === undefined) return;
-    colState.config.outlierMethod = def.outlierMethod;
-    colState.config.outlierStrategy = def.outlierStrategy;
-    this.preprocessingService.updateColumnConfig(colState.column.name, {
-      outlierMethod: def.outlierMethod,
-      outlierStrategy: def.outlierStrategy,
-    });
+  async resetOutlierMethod(colState: ColumnConfigState): Promise<void> {
+    const method = this.getDefaults(colState).outlierMethod;
+    if (method === undefined) return;
+    colState.config.outlierMethod = method;
+    this.preprocessingService.updateColumnConfig(colState.column.name, { outlierMethod: method });
     await this.detectOutliersForColumn(colState);
+  }
+
+  resetOutlierStrategy(colState: ColumnConfigState): void {
+    const strategy = this.getDefaults(colState).outlierStrategy;
+    if (strategy === undefined) return;
+    colState.config.outlierStrategy = strategy;
+    this.preprocessingService.updateColumnConfig(colState.column.name, { outlierStrategy: strategy });
+  }
+
+  async resetOutliers(colState: ColumnConfigState): Promise<void> {
+    this.resetOutlierStrategy(colState);
+    await this.resetOutlierMethod(colState);
   }
 
   /** Reset every setting of the selected column back to its smart default. */
@@ -416,12 +461,43 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
   // A9 – Bulk apply settings to all columns of the same type
   // ============================================================================
 
+  /** Other enabled columns that share the selected column's data type. */
   getSameTypeColumns(colState: ColumnConfigState): ColumnConfigState[] {
     return this.columns.filter(
       c => c.column.dataType === colState.column.dataType && c.column.name !== colState.column.name
     );
   }
 
+  /** Toggle the progressive-disclosure list of columns a bulk apply would touch. */
+  toggleBulkTargets(): void {
+    this.showBulkTargets = !this.showBulkTargets;
+  }
+
+  /** Human-readable summary of the settings a bulk apply copies over. */
+  getBulkSettingsSummary(source: ColumnConfigState): string {
+    const parts: string[] = [];
+    const enc = this.encodingMethods.find(m => m.value === source.config.encodingMethod);
+    if (enc) parts.push(`Encoding: ${enc.label}`);
+    if (this.shouldShowScaling(source)) {
+      const sc = this.scalingMethods.find(m => m.value === source.config.scalingMethod);
+      if (sc) parts.push(`Scaling: ${sc.label}`);
+    }
+    const miss = this.missingValueStrategies.find(m => m.value === source.config.missingValueStrategy);
+    if (miss) parts.push(`Missing: ${miss.label}`);
+    if (this.shouldShowOutliers(source)) {
+      const om = this.outlierMethods.find(m => m.value === source.config.outlierMethod);
+      const os = this.outlierStrategies.find(m => m.value === source.config.outlierStrategy);
+      if (om && os) parts.push(`Outliers: ${om.label} / ${os.label}`);
+    }
+    return parts.join(' · ');
+  }
+
+  /**
+   * Copies the selected column's settings onto every other column of the same type.
+   * Runs ONLY from an explicit button click — never as a side effect of editing a
+   * single column. Missing-value handling is copied too, but on columns without any
+   * missing values it simply has no effect.
+   */
   applyToSameType(source: ColumnConfigState): void {
     const targets = this.getSameTypeColumns(source);
     if (targets.length === 0) return;
@@ -442,6 +518,19 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
         void this.detectOutliersForColumn(target);
       }
     }
+
+    // Confirmation summary shown after the apply completes.
+    this.bulkApplyResult = {
+      sourceName: source.column.name,
+      typeLabel: this.getTypeLabel(source.column.dataType),
+      columnNames: targets.map(t => t.column.name),
+      settingsSummary: this.getBulkSettingsSummary(source),
+    };
+    this.showBulkTargets = false;
+  }
+
+  dismissBulkResult(): void {
+    this.bulkApplyResult = null;
   }
 
   /** Focus the column search field when the user presses "/" (unless already typing). */


### PR DESCRIPTION
## Tickets
A2 (Voreinstellungen sichtbar/umkehrbar) + A9 (Beschleuniger für Power-Nutzer). Zusammengelegt, weil beide step2/step3 berühren.

## Was gemacht
**A2**
- „Smart defaults applied"-Banner in Schritt 3 entfernt.
- Default-Vergleich im Service (`getColumnDefaults`) auf Basis `DATA_TYPE_CONFIG`; pro Feld `isEncoding/Scaling/Missing/OutlierModified` + `isColumnModified`.
- Reset-Controls erscheinen **nur bei Abweichung**: pro Einstellung ein „Reset" im Section-Header, plus „Reset to defaults" für die ganze Spalte (Stil an step4 `resetMethodParams` angelehnt).
- Spalten-Vorauswahl: `createDefaultColumnConfig` setzt `enabled: !hasIssues` (missing > 50 % oder uniqueCount === 1), in step2 umkehrbar.

**A9**
- Shift-Klick-Range-Select in step2 (auf der gefilterten Liste).
- Select-all/Tri-State bezieht sich jetzt auf die gefilterte Menge (`filteredColumns`).
- Bulk „Apply to all N \<Type\> columns" im step3-Detail-Well (Encoding/Scaling/Missing/Outlier auf gleichtypige Spalten).
- `/`-Shortcut fokussiert das Suchfeld (step2/step3), ignoriert Eingabe in Feldern.

Drag-and-drop (step4) und `resetMethodParams` bewusst unberührt.

## Manuelle Testschritte (Schritt → Ort → Erwartung)
1. CSV mit Spalte >50 % Missing oder konstant laden → Schritt 2 → Spalte ist per Default abgewählt, reaktivierbar.
2. Shift-Klick zwischen zwei Checkboxen → Schritt 2 → alle Zeilen dazwischen (gefilterte Sicht) toggeln.
3. Suche/Typ filtern, dann Header-Checkbox → Schritt 2 → nur sichtbare Spalten umgeschaltet; Tri-State spiegelt gefilterte Menge.
4. Encoding einer Spalte ändern → Schritt 3, Detail-Well → „Reset" neben „Encoding" + „Reset to defaults" erscheinen; Klick stellt Default wieder her, Button verschwindet.
5. Spalte konfigurieren, „Apply to all N \<Type\> columns" → Schritt 3 → gleichtypige Spalten übernehmen die Einstellungen.
6. `/` drücken (nicht in einem Feld) → Schritt 2/3 → Suchfeld erhält Fokus.

## Build
`npm run build` erfolgreich; nur die vorbestehende Bundle-Budget-Warnung.

## Hinweis
Überschneidet sich in `preprocessing.service.ts` und `step2-column-selection` mit PR A6/A8 — beim zweiten Merge sind dort Konflikte zu erwarten.
