### PR TITLE
feat(a6/a8): Review-Direktlinks und korrekte Datenanzeige

### DIFF
--- a/src/app/preprocessing-wizard/services/preprocessing.service.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.ts
@@ -29,6 +29,10 @@ export class PreprocessingService {
   private progressSubject = new Subject<ProcessingProgress>();
   public progress$ = this.progressSubject.asObservable();
 
+  // A6: pending scroll anchor id set by the review step's deep-links. The target
+  // step component consumes it once after it renders and scrolls into view.
+  private scrollTargetSubject = new BehaviorSubject<string | null>(null);
+
   constructor(
     private dataProcessor: DataProcessorService,
     private dataLoader: DataLoaderService
@@ -95,6 +99,22 @@ export class PreprocessingService {
     if (step >= 0 && step <= 4) {
       this.updateState({ currentStep: step });
     }
+  }
+
+  // A6: navigate to a step and remember an anchor id so the target step can
+  // scroll the relevant setting into view after it renders.
+  public goToStepWithScroll(step: number, targetId: string): void {
+    this.goToStep(step);
+    this.scrollTargetSubject.next(targetId);
+  }
+
+  // A6: read and clear the pending scroll anchor. Returns null if none is set.
+  public consumeScrollTarget(): string | null {
+    const target = this.scrollTargetSubject.getValue();
+    if (target) {
+      this.scrollTargetSubject.next(null);
+    }
+    return target;
   }
 
   public nextStep(): void {

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.html
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.html
@@ -9,6 +9,7 @@
       </div>
     </div>
 
+    <span id="wizard-anchor-columns" class="scroll-anchor"></span>
     <div class="column-actions">
       <div class="search-box">
         <span class="material-icons">search</span>
@@ -134,7 +135,7 @@
                       <span class="missing-percent warn">({{ column.missingPercentage.toFixed(1) }}%)</span>
                     </div>
                   } @else {
-                    <span class="text-muted">—</span>
+                    <span class="missing-count-zero">0</span>
                   }
                 </td>
 

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.scss
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.scss
@@ -195,6 +195,18 @@
   font-style: italic;
 }
 
+// A8: an explicit "0" for zero missing values (calm, not alarming)
+.missing-count-zero {
+  color: v.$gray-500;
+}
+
+// A6: invisible scroll anchor used by the review step's deep-links
+.scroll-anchor {
+  display: block;
+  height: 0;
+  scroll-margin-top: 12px;
+}
+
 // No Results
 .no-results {
   @include wizard.no-content($padding: 48px 24px, $text-size: 14px);

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.ts
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, forwardRef } from '@angular/core';
+import { Component, OnInit, AfterViewInit, forwardRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { PreprocessingService } from '../../services/preprocessing.service';
@@ -20,7 +20,7 @@ import { WizardStep, WIZARD_STEP } from '../../shared/wizard-step';
   styleUrl: './step2-column-selection.component.scss',
   providers: [{ provide: WIZARD_STEP, useExisting: forwardRef(() => Step2ColumnSelectionComponent) }],
 })
-export class Step2ColumnSelectionComponent implements OnInit, WizardStep {
+export class Step2ColumnSelectionComponent implements OnInit, AfterViewInit, WizardStep {
   readonly primaryLabel = 'Continue to Configure Data & Features';
   readonly disabledHint = 'Please select at least one column to continue';
 
@@ -40,6 +40,17 @@ export class Step2ColumnSelectionComponent implements OnInit, WizardStep {
   readonly stepInfo = STEP_INFO[1]; // Step 2 (index 1)
 
   constructor(private preprocessingService: PreprocessingService) {}
+
+  // A6: scroll the requested setting into view when arriving via a review deep-link.
+  // The delay lets the shell's scroll-to-top run first so it does not override this.
+  ngAfterViewInit(): void {
+    const target = this.preprocessingService.consumeScrollTarget();
+    if (target) {
+      setTimeout(() => {
+        document.getElementById(target)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 120);
+    }
+  }
 
   ngOnInit(): void {
     const state = this.preprocessingService.currentState;

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -302,6 +302,34 @@
           <span>{{ getDatasetRowCount() | number }} rows in dataset</span>
         </p>
 
+        <!-- Search + type filter (mirrors the glyph feature filter bar) -->
+        <div class="feature-filter-bar">
+          <div class="search-box">
+            <span class="material-icons">search</span>
+            <input
+              type="text"
+              [(ngModel)]="projectionColumnSearch"
+              placeholder="Search columns…"
+              class="search-input"
+            />
+            @if (projectionColumnSearch) {
+              <button class="clear-search" (click)="projectionColumnSearch = ''">
+                <span class="material-icons">close</span>
+              </button>
+            }
+          </div>
+          <select [(ngModel)]="projectionColumnTypeFilter" class="filter-select">
+            <option value="all">All Types</option>
+            <option [value]="DataType.Numeric">Numeric</option>
+            <option [value]="DataType.Categorical">Categorical</option>
+            <option [value]="DataType.Text">Text</option>
+            <option [value]="DataType.Date">Date</option>
+            <option [value]="DataType.Boolean">Boolean</option>
+            <option [value]="DataType.Coordinate">Coordinate</option>
+            <option [value]="DataType.ID">ID</option>
+          </select>
+        </div>
+
         <div class="projection-columns-list-header">
           <input
             type="checkbox"
@@ -312,23 +340,74 @@
             title="Select all columns"
           />
           <span class="master-label">All columns</span>
+          @if (hasProjectionColumnFilter()) {
+            <span class="showing-count">Showing {{ filteredProjectionColumns.length }} of {{ projectionColumns.length }}</span>
+          }
         </div>
 
         <div class="projection-columns-list">
-          @for (entry of projectionColumns; track entry.column.name) {
-            <label
+          @for (entry of filteredProjectionColumns; track entry.column.name) {
+            <div
               class="projection-column-item"
               [class.selected]="entry.config.includeInProjection"
               [class.excluded]="!entry.config.includeInProjection"
+              [class.details-open]="isProjectionDetailsExpanded(entry.column.name)"
             >
-              <input
-                type="checkbox"
-                [checked]="entry.config.includeInProjection"
-                (change)="toggleColumnProjection(entry.column.name)"
-              />
-              <span class="col-name">{{ entry.column.name }}</span>
-              <app-data-type-badge [dataType]="entry.column.dataType"></app-data-type-badge>
-            </label>
+              <label class="projection-column-row">
+                <input
+                  type="checkbox"
+                  [checked]="entry.config.includeInProjection"
+                  (change)="toggleColumnProjection(entry.column.name)"
+                />
+                <span class="col-name">{{ entry.column.name }}</span>
+                <app-data-type-badge [dataType]="entry.column.dataType"></app-data-type-badge>
+                <button
+                  type="button"
+                  class="btn-details-toggle"
+                  [title]="isProjectionDetailsExpanded(entry.column.name) ? 'Hide details' : 'Show details'"
+                  (click)="toggleProjectionDetails(entry.column.name, $event)"
+                >
+                  <span class="material-icons">
+                    {{ isProjectionDetailsExpanded(entry.column.name) ? 'expand_less' : 'expand_more' }}
+                  </span>
+                </button>
+              </label>
+
+              @if (isProjectionDetailsExpanded(entry.column.name)) {
+                <div class="projection-column-details">
+                  <div class="detail-row">
+                    <span class="detail-key">Encoding</span>
+                    <span class="detail-val">{{ getEncodingLabel(entry.config.encodingMethod) }}</span>
+                  </div>
+                  <div class="detail-row">
+                    <span class="detail-key">Scaling</span>
+                    <span class="detail-val">
+                      @if (entry.column.dataType === DataType.Numeric || entry.column.dataType === DataType.Date) {
+                        {{ getScalingLabel(entry.config.scalingMethod) }}
+                      } @else {
+                        N/A
+                      }
+                    </span>
+                  </div>
+                  <div class="detail-row">
+                    <span class="detail-key">Missing</span>
+                    <span class="detail-val">{{ getMissingLabel(entry.config.missingValueStrategy) }}</span>
+                  </div>
+                  <div class="detail-hint">
+                    <span class="material-icons">edit</span>
+                    <span>Adjust these in step “Configure Data &amp; Features”.</span>
+                  </div>
+                </div>
+              }
+            </div>
+          }
+          @if (filteredProjectionColumns.length === 0) {
+            <div class="available-empty">
+              <span>No columns match</span>
+              @if (hasProjectionColumnFilter()) {
+                <button class="btn-clear-inline" (click)="clearProjectionColumnFilters()">Clear filters</button>
+              }
+            </div>
           }
         </div>
 
@@ -341,8 +420,8 @@
       </div>
 
       <!-- RIGHT: Projection method selection -->
-      <span id="wizard-anchor-methods" class="scroll-anchor"></span>
       <div class="config-panel projection-panel">
+      <span id="wizard-anchor-methods" class="scroll-anchor"></span>
       <div class="projection-panel-header">
         <h3>
           <span class="material-icons">settings</span>

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -1,6 +1,7 @@
 <div class="step4-visualization-settings">
   <div class="step-content">
     <!-- ====== Color Feature (single row) ====== -->
+    <span id="wizard-anchor-color" class="scroll-anchor"></span>
     <div class="config-panel color-feature-panel">
       <div class="panel-header-row">
         <div class="form-group">
@@ -26,6 +27,7 @@
     </div>
 
     <!-- ====== Two-Column: Glyph Features + Live Preview ====== -->
+    <span id="wizard-anchor-glyph" class="scroll-anchor"></span>
     <div class="glyph-section-two-col">
       <!-- LEFT: Feature Selection -->
       <div class="config-panel glyph-features-panel">
@@ -282,6 +284,7 @@
     </div>
 
     <!-- ====== Projection Options (columns + method, two-column layout) ====== -->
+    <span id="wizard-anchor-projection-columns" class="scroll-anchor"></span>
     <div class="projection-options-two-col">
       <!-- LEFT: Columns feeding the projection -->
       <div class="config-panel projection-columns-panel">
@@ -294,6 +297,10 @@
           <span class="projection-count">{{ getProjectionCount() }} / {{ projectionColumns.length }} included</span>
         </div>
         <p class="panel-description">Choose which columns feed the dimensionality reduction.</p>
+        <p class="dataset-row-count">
+          <span class="material-icons">table_rows</span>
+          <span>{{ getDatasetRowCount() | number }} rows in dataset</span>
+        </p>
 
         <div class="projection-columns-list-header">
           <input
@@ -334,6 +341,7 @@
       </div>
 
       <!-- RIGHT: Projection method selection -->
+      <span id="wizard-anchor-methods" class="scroll-anchor"></span>
       <div class="config-panel projection-panel">
       <div class="projection-panel-header">
         <h3>

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -3,6 +3,13 @@
 @use '../../../../styles/variables' as v;
 @use '../../../../styles/mixins' as m;
 
+// A6: invisible scroll anchor used by the review step's deep-links
+.scroll-anchor {
+  display: block;
+  height: 0;
+  scroll-margin-top: 12px;
+}
+
 .step4-visualization-settings {
   display: flex;
   flex-direction: column;
@@ -773,6 +780,21 @@
     display: flex;
     flex-direction: column;
     max-height: 420px;
+
+    // A8: total dataset row count for context
+    .dataset-row-count {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 11px;
+      color: v.$gray-600;
+      margin: -4px 0 10px;
+
+      .material-icons {
+        font-size: 14px;
+        color: v.$gray-500;
+      }
+    }
 
     .projection-columns-header {
       @include w.list-header-row;

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -766,13 +766,16 @@
 
   .projection-options-two-col {
     display: grid;
+    // Always side-by-side (columns left, methods right), even at narrower widths.
     grid-template-columns: 2fr 3fr;
     gap: 16px;
     align-items: start;
 
-    // Panels inside the grid should not add their own bottom margin
-    .config-panel {
+    // Panels inside the grid should not add their own bottom margin and must be
+    // allowed to shrink so long column names never force the grid to wrap.
+    > .config-panel {
       margin-bottom: 0;
+      min-width: 0;
     }
   }
 
@@ -821,6 +824,28 @@
       }
     }
 
+    // Search + type filter (same visual language as the glyph feature filter)
+    .feature-filter-bar {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 6px;
+
+      .search-box {
+        @include w.search-box($padding: 4px 8px, $icon-size: 16px);
+        flex: 1;
+        min-width: 0;
+      }
+
+      .filter-select {
+        @include w.select;
+        font-size: 12px;
+        padding: 4px 24px 4px 8px;
+        flex-shrink: 0;
+        max-width: 120px;
+      }
+    }
+
     .projection-columns-list-header {
       @include w.list-header-row;
       gap: 8px;
@@ -844,6 +869,14 @@
         letter-spacing: 0.3px;
         text-transform: uppercase;
       }
+
+      .showing-count {
+        margin-left: auto;
+        font-size: 11px;
+        font-weight: 600;
+        color: v.$active-color;
+        white-space: nowrap;
+      }
     }
 
     .projection-columns-list {
@@ -855,16 +888,14 @@
       min-height: 0;
     }
 
+    // Compact row wrapper: holds the selectable row plus an optional details panel.
     .projection-column-item {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 5px 8px;
       border: 1px solid v.$gray-200;
       border-radius: 6px;
-      cursor: pointer;
       font-size: 12px;
-      transition: all 0.15s ease;
+      transition:
+        border-color 0.15s ease,
+        background 0.15s ease;
 
       &:hover {
         border-color: v.$gray-400;
@@ -875,9 +906,23 @@
         border-color: rgba(v.$active-color, 0.3);
       }
 
+      &.details-open {
+        border-color: rgba(v.$active-color, 0.3);
+      }
+
       &.excluded .col-name {
         color: v.$gray-500;
         text-decoration: line-through;
+      }
+
+      // The clickable row itself is dense (compact padding to save width).
+      .projection-column-row {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        padding: 3px 6px;
+        cursor: pointer;
+        margin: 0;
       }
 
       input[type='checkbox'] {
@@ -893,6 +938,88 @@
         font-weight: 500;
         color: v.$gray-800;
         @include m.text-truncate;
+      }
+
+      .btn-details-toggle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 22px;
+        height: 22px;
+        padding: 0;
+        background: transparent;
+        border: none;
+        border-radius: 4px;
+        color: v.$gray-500;
+        cursor: pointer;
+        flex-shrink: 0;
+
+        .material-icons {
+          font-size: 18px;
+        }
+
+        &:hover {
+          color: v.$status-info;
+          background: rgba(v.$active-color, 0.1);
+        }
+      }
+
+      // Progressive-disclosure details: encoding / scaling / missing per column.
+      .projection-column-details {
+        display: flex;
+        flex-direction: column;
+        gap: 3px;
+        padding: 6px 8px 8px;
+        border-top: 1px dashed v.$gray-200;
+        margin-top: 2px;
+
+        .detail-row {
+          display: flex;
+          justify-content: space-between;
+          gap: 8px;
+
+          .detail-key {
+            color: v.$gray-500;
+            text-transform: uppercase;
+            font-size: 10px;
+            letter-spacing: 0.3px;
+          }
+
+          .detail-val {
+            color: v.$gray-800;
+            font-weight: 500;
+          }
+        }
+
+        .detail-hint {
+          display: flex;
+          align-items: center;
+          gap: 4px;
+          margin-top: 2px;
+          color: v.$gray-500;
+          font-size: 10px;
+
+          .material-icons {
+            font-size: 12px;
+          }
+        }
+      }
+    }
+
+    // Empty state when search/filter matches nothing
+    .available-empty {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 6px;
+      padding: 16px 8px;
+      color: v.$gray-500;
+      font-size: 12px;
+
+      .btn-clear-inline {
+        @include w.btn-text;
+        font-size: 11px;
+        padding: 3px 8px;
       }
     }
 

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
@@ -5,7 +5,12 @@ import { PreprocessingService } from '../../services/preprocessing.service';
 import { WizardStep, WIZARD_STEP } from '../../shared/wizard-step';
 import { ColumnConfig, ProjectionConfig } from '../../models/column-config';
 import { ColumnStatistics } from '../../models/column-statistics';
-import { DataType } from '../../models/data-type.enum';
+import {
+  DataType,
+  MissingValueStrategy,
+  getEncodingLabel as encodingLabelFn,
+  getScalingLabel as scalingLabelFn,
+} from '../../models/data-type.enum';
 import { HelpTooltipComponent } from '../../shared/help-tooltip/help-tooltip.component';
 import { HELP_TEXT } from '../../shared/constants/help-text';
 import { STEP_INFO } from '../../shared/constants/step-info';
@@ -74,6 +79,16 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
 
   // Projection column selection (which features feed the dimensionality reduction)
   projectionColumns: ProjectionColumnState[] = [];
+
+  // Search + type filter for the projection column list (mirrors the glyph feature filter).
+  projectionColumnSearch = '';
+  projectionColumnTypeFilter: DataType | 'all' = 'all';
+  // Names of columns whose per-column details (encoding/scaling/missing) are expanded.
+  private expandedProjectionDetails = new Set<string>();
+
+  // Label helpers for the per-column details toggle.
+  readonly getEncodingLabel = encodingLabelFn;
+  readonly getScalingLabel = scalingLabelFn;
 
   // Color feature selection
   columns: ColumnStatistics[] = [];
@@ -623,6 +638,55 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
 
   isColumnInProjection(columnName: string): boolean {
     return this.projectionColumns.find(c => c.column.name === columnName)?.config.includeInProjection ?? false;
+  }
+
+  /** Projection columns filtered by the search box and the type filter. */
+  get filteredProjectionColumns(): ProjectionColumnState[] {
+    const term = this.projectionColumnSearch.trim().toLowerCase();
+    return this.projectionColumns.filter(entry => {
+      if (term && !entry.column.name.toLowerCase().includes(term)) return false;
+      if (this.projectionColumnTypeFilter !== 'all' && entry.column.dataType !== this.projectionColumnTypeFilter) {
+        return false;
+      }
+      return true;
+    });
+  }
+
+  hasProjectionColumnFilter(): boolean {
+    return this.projectionColumnSearch.trim() !== '' || this.projectionColumnTypeFilter !== 'all';
+  }
+
+  clearProjectionColumnFilters(): void {
+    this.projectionColumnSearch = '';
+    this.projectionColumnTypeFilter = 'all';
+  }
+
+  /** Toggle the per-column details panel (encoding/scaling/missing) for progressive disclosure. */
+  toggleProjectionDetails(columnName: string, event?: Event): void {
+    event?.stopPropagation();
+    event?.preventDefault();
+    if (this.expandedProjectionDetails.has(columnName)) {
+      this.expandedProjectionDetails.delete(columnName);
+    } else {
+      this.expandedProjectionDetails.add(columnName);
+    }
+  }
+
+  isProjectionDetailsExpanded(columnName: string): boolean {
+    return this.expandedProjectionDetails.has(columnName);
+  }
+
+  /** Human-readable label for the configured missing-value strategy. */
+  getMissingLabel(strategy: MissingValueStrategy): string {
+    const labels: Record<MissingValueStrategy, string> = {
+      [MissingValueStrategy.Keep]: 'Keep',
+      [MissingValueStrategy.RemoveRows]: 'Remove rows',
+      [MissingValueStrategy.FillMean]: 'Fill mean',
+      [MissingValueStrategy.FillMedian]: 'Fill median',
+      [MissingValueStrategy.FillMode]: 'Fill mode',
+      [MissingValueStrategy.FillValue]: 'Fill value',
+    };
+    return labels[strategy] ?? 'Keep';
   }
 
   getProjectionCount(): number {

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, forwardRef } from '@angular/core';
+import { Component, OnInit, AfterViewInit, forwardRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { PreprocessingService } from '../../services/preprocessing.service';
@@ -68,7 +68,7 @@ interface ProjectionMethodUI {
   styleUrl: './step4-visualization-settings.component.scss',
   providers: [{ provide: WIZARD_STEP, useExisting: forwardRef(() => Step4VisualizationSettingsComponent) }],
 })
-export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
+export class Step4VisualizationSettingsComponent implements OnInit, AfterViewInit, WizardStep {
   readonly primaryLabel = 'Continue to Review';
   readonly disabledHint = 'Select at least one projection column and 3-12 glyph features to continue.';
 
@@ -293,6 +293,18 @@ export class Step4VisualizationSettingsComponent implements OnInit, WizardStep {
   readonly stepInfo = STEP_INFO[3]; // Step 4 (index 3)
 
   constructor(public preprocessingService: PreprocessingService) {}
+
+  // A6: if the review step requested a jump to a specific setting, scroll its
+  // anchor into view once this step has rendered. The delay lets the shell's
+  // scroll-to-top run first so it does not override this.
+  ngAfterViewInit(): void {
+    const target = this.preprocessingService.consumeScrollTarget();
+    if (target) {
+      setTimeout(() => {
+        document.getElementById(target)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 120);
+    }
+  }
 
   ngOnInit(): void {
     const state = this.preprocessingService.currentState;

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.html
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.html
@@ -13,6 +13,14 @@
               <span class="card-label">Columns Selected</span>
               <span class="card-value">{{ enabledColumns }} / {{ totalColumns }}</span>
             </div>
+            <button
+              type="button"
+              class="card-edit-btn"
+              title="Edit column selection"
+              (click)="editSetting(1, 'wizard-anchor-columns')"
+            >
+              <span class="material-icons">edit</span>
+            </button>
           </div>
 
           <div class="summary-card">
@@ -21,6 +29,14 @@
               <span class="card-label">Projection Features</span>
               <span class="card-value">{{ projectionColumns }}</span>
             </div>
+            <button
+              type="button"
+              class="card-edit-btn"
+              title="Edit projection columns"
+              (click)="editSetting(3, 'wizard-anchor-projection-columns')"
+            >
+              <span class="material-icons">edit</span>
+            </button>
           </div>
 
           <div class="summary-card">
@@ -29,6 +45,14 @@
               <span class="card-label">Color Feature</span>
               <span class="card-value">{{ colorFeature || 'None' }}</span>
             </div>
+            <button
+              type="button"
+              class="card-edit-btn"
+              title="Edit color feature"
+              (click)="editSetting(3, 'wizard-anchor-color')"
+            >
+              <span class="material-icons">edit</span>
+            </button>
           </div>
 
           <div class="summary-card">
@@ -37,6 +61,14 @@
               <span class="card-label">Glyph Features</span>
               <span class="card-value">{{ selectedGlyphFeatures.length }}</span>
             </div>
+            <button
+              type="button"
+              class="card-edit-btn"
+              title="Edit glyph features"
+              (click)="editSetting(3, 'wizard-anchor-glyph')"
+            >
+              <span class="material-icons">edit</span>
+            </button>
           </div>
 
           <div class="summary-card">
@@ -45,6 +77,14 @@
               <span class="card-label">Projection Methods</span>
               <span class="card-value">{{ enabledMethods.join(', ') }}</span>
             </div>
+            <button
+              type="button"
+              class="card-edit-btn"
+              title="Edit projection methods"
+              (click)="editSetting(3, 'wizard-anchor-methods')"
+            >
+              <span class="material-icons">edit</span>
+            </button>
           </div>
         </div>
 

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.scss
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.scss
@@ -32,7 +32,7 @@
         border: 1px solid v.$gray-300;
         border-radius: 4px;
 
-        // A6: edit/jump affordance per summary card
+        // A6: edit/jump affordance per summary card — uniform, borderless icon button
         .card-edit-btn {
           margin-left: auto;
           align-self: flex-start;
@@ -43,22 +43,20 @@
           height: 28px;
           padding: 0;
           background: transparent;
-          border: 1px solid v.$gray-300;
+          border: none;
           border-radius: 4px;
-          color: v.$gray-600;
+          color: v.$gray-500;
           cursor: pointer;
           transition:
             color 0.15s ease,
-            border-color 0.15s ease,
             background 0.15s ease;
 
           .material-icons {
-            font-size: 16px;
+            font-size: 18px;
           }
 
           &:hover {
             color: v.$status-info;
-            border-color: v.$active-color;
             background: rgba(v.$active-color, 0.1);
           }
 

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.scss
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.scss
@@ -32,6 +32,42 @@
         border: 1px solid v.$gray-300;
         border-radius: 4px;
 
+        // A6: edit/jump affordance per summary card
+        .card-edit-btn {
+          margin-left: auto;
+          align-self: flex-start;
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          width: 28px;
+          height: 28px;
+          padding: 0;
+          background: transparent;
+          border: 1px solid v.$gray-300;
+          border-radius: 4px;
+          color: v.$gray-600;
+          cursor: pointer;
+          transition:
+            color 0.15s ease,
+            border-color 0.15s ease,
+            background 0.15s ease;
+
+          .material-icons {
+            font-size: 16px;
+          }
+
+          &:hover {
+            color: v.$status-info;
+            border-color: v.$active-color;
+            background: rgba(v.$active-color, 0.1);
+          }
+
+          &:focus-visible {
+            outline: 2px solid v.$active-color;
+            outline-offset: 1px;
+          }
+        }
+
         .card-icon {
           display: flex;
           align-items: center;

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.ts
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.ts
@@ -357,6 +357,12 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
     this.preprocessingService.previousStep();
   }
 
+  // A6: jump from a review summary card back to the step that owns that setting
+  // and scroll the relevant section into view.
+  editSetting(step: number, targetId: string): void {
+    this.preprocessingService.goToStepWithScroll(step, targetId);
+  }
+
   startOver(): void {
     if (confirm('Are you sure you want to start over? All current configuration will be lost.')) {
       // Terminate any running background projection workers


### PR DESCRIPTION
## Tickets
A6 (Navigation im Review-Schritt) + A8 (Systemstatus/Datenanzeige). Zusammengelegt als kleiner, zusammenhängender Feinschliff-Block.

## Was gemacht
**A6 – Review-Direktlinks**
- Pro Summary-Card in step5 ein Edit-Icon-Button → `editSetting(step, anchorId)` → `goToStepWithScroll(...)`.
- Scroll-to-target: `scrollTargetSubject` (BehaviorSubject) im Service; Zielkomponente liest die Anchor-Id in `ngAfterViewInit` (`consumeScrollTarget`, einmalig) und scrollt per `scrollIntoView({behavior:'smooth',block:'start'})` (kleines Delay nach dem shell-eigenen scroll-to-top). Unsichtbare `scroll-anchor`-Anker, additiv. Keine URL/Query-Deep-Links.
- Mapping: Columns → Schritt 2; Projection Features/Color/Glyph/Methods → Schritt 4 (jeweiliges Panel).

**A8 – Datenanzeige**
- Missing-Count „—" → „0": gezielt nur die step2-Statistikspalte bei 0 Missing. Rohdatenzellen (`data-preview-table.getCellValue`) und Distribution-`—` bewusst unangetastet.
- „N rows in dataset" im step4-Projektionspanel über bestehendes `getDatasetRowCount()`.

## Manuelle Testschritte (Schritt → Ort → Erwartung)
1. Datensatz bis Review (Schritt 5) → jede Summary-Card zeigt rechts einen Edit-Button.
2. Edit bei „Color Feature" → Schritt 4, scrollt sanft zum Color-Panel.
3. Edit bei „Projection Methods"/„Glyph Features"/„Projection Features" → Schritt 4, scrollt zum jeweiligen Panel.
4. Edit bei „Columns Selected" → Schritt 2, scrollt zur Spaltenauswahl.
5. Spalte ohne fehlende Werte → Schritt 2, Missing-Spalte → zeigt „0" (nicht „—").
6. Schritt 4, Projektionspanel → „N rows in dataset" mit Tausendertrennung.

## Build
`npm run build` erfolgreich; nur die vorbestehende Bundle-Budget-Warnung.

## Hinweis
Überschneidet sich in `preprocessing.service.ts` und `step2-column-selection` mit PR A2/A9 — beim zweiten Merge sind dort Konflikte zu erwarten.
