### PR TITLE
feat(a10/a7): Layout-Robustheit und ehrliche Signifier

### DIFF
--- a/src/app/preprocessing-wizard/shared/data-preview-table/data-preview-table.component.html
+++ b/src/app/preprocessing-wizard/shared/data-preview-table/data-preview-table.component.html
@@ -7,7 +7,7 @@
         <thead>
           <tr>
             @for (column of displayColumns; track column) {
-              <th [class.highlighted]="isColumnHighlighted(column)">
+              <th [class.highlighted]="isColumnHighlighted(column)" [title]="column">
                 {{ column }}
               </th>
             }
@@ -17,7 +17,7 @@
           @for (row of displayData; track $index) {
             <tr>
               @for (column of displayColumns; track column) {
-                <td [class.highlighted]="isColumnHighlighted(column)">
+                <td [class.highlighted]="isColumnHighlighted(column)" [title]="getCellValue(row, column)">
                   {{ getCellValue(row, column) }}
                 </td>
               }

--- a/src/app/preprocessing-wizard/shared/progress-stepper/progress-stepper.component.scss
+++ b/src/app/preprocessing-wizard/shared/progress-stepper/progress-stepper.component.scss
@@ -45,7 +45,7 @@
       }
 
       &.active {
-        background: rgba(68, 138, 255, 0.1);
+        background: rgba(v.$active-color, 0.12);
       }
     }
 
@@ -135,8 +135,15 @@
   width: 110px;
   flex-shrink: 0;
 
+  // Reachable steps read as enabled/interactive (accent outline), not greyed
+  // out like the disabled future steps.
   &.clickable {
     cursor: pointer;
+
+    .step-circle {
+      border-color: v.$active-color;
+      color: v.$active-color;
+    }
 
     &:hover .step-circle {
       opacity: 0.8;
@@ -183,6 +190,10 @@
   color: v.$gray-600;
   text-align: center;
   line-height: 1.3;
+
+  .clickable & {
+    color: v.$gray-700;
+  }
 
   .active & {
     color: v.$active-color;

--- a/src/app/preprocessing-wizard/shared/progress-stepper/progress-stepper.component.scss
+++ b/src/app/preprocessing-wizard/shared/progress-stepper/progress-stepper.component.scss
@@ -135,31 +135,30 @@
   width: 110px;
   flex-shrink: 0;
 
-  // Reachable steps read as enabled/interactive (accent outline), not greyed
-  // out like the disabled future steps.
+  // Reachable steps stay interactive (pointer + subtle hover); the three
+  // visual states below are driven purely by completed/active, not clickability.
   &.clickable {
     cursor: pointer;
 
-    .step-circle {
-      border-color: v.$active-color;
-      color: v.$active-color;
-    }
-
     &:hover .step-circle {
-      opacity: 0.8;
+      opacity: 0.85;
     }
   }
 
-  &.active .step-circle {
+  // Completed: cyan-filled circle with a white check mark.
+  &.completed .step-circle {
     background: v.$active-color;
     color: v.$white;
     border-color: v.$active-color;
   }
 
-  &.completed .step-circle {
-    background: v.$gray-600;
-    color: v.$white;
-    border-color: v.$gray-600;
+  // Active: the step number on a white circle framed by a cyan ring. Declared
+  // after .completed so a revisited (already completed) step still shows this
+  // ring while it is the current step.
+  &.active .step-circle {
+    background: v.$white;
+    color: v.$active-color;
+    border-color: v.$active-color;
   }
 }
 
@@ -223,7 +222,7 @@
   transition: background 0.2s ease;
 
   &.completed {
-    background: v.$gray-600;
+    background: v.$active-color;
   }
 }
 

--- a/src/app/preprocessing-wizard/shared/progress-stepper/progress-stepper.component.ts
+++ b/src/app/preprocessing-wizard/shared/progress-stepper/progress-stepper.component.ts
@@ -35,9 +35,27 @@ export class ProgressStepperComponent {
   }
 
   isStepClickable(index: number): boolean {
-    // Allow clicking on:
-    // 1. Any previous step (go back)
-    // 2. Any completed step (including forward navigation to re-visit completed steps)
-    return index <= this.currentStep || this.steps[index]?.completed;
+    // Reachable steps are:
+    // 1. The current step and every step before it (go back at will)
+    // 2. Any step already completed
+    // 3. The step directly after the furthest completed step, so the next
+    //    step to fill in stays reachable even after navigating backwards
+    if (index <= this.currentStep) {
+      return true;
+    }
+    if (this.steps[index]?.completed) {
+      return true;
+    }
+    return index <= this.lastCompletedStepIndex() + 1;
+  }
+
+  private lastCompletedStepIndex(): number {
+    let last = -1;
+    for (let i = 0; i < this.steps.length; i++) {
+      if (this.steps[i]?.completed) {
+        last = i;
+      }
+    }
+    return last;
   }
 }

--- a/src/app/preprocessing-wizard/steps/step1-upload/step1-upload.component.html
+++ b/src/app/preprocessing-wizard/steps/step1-upload/step1-upload.component.html
@@ -89,7 +89,7 @@
             <span class="material-icons">description</span>
             <div class="stat-content">
               <div class="stat-label">File Name</div>
-              <div class="stat-value">{{ profile.fileName }}</div>
+              <div class="stat-value" [title]="profile.fileName">{{ profile.fileName }}</div>
             </div>
           </div>
 

--- a/src/app/preprocessing-wizard/steps/step1-upload/step1-upload.component.scss
+++ b/src/app/preprocessing-wizard/steps/step1-upload/step1-upload.component.scss
@@ -1,4 +1,5 @@
 @use '../../../../styles/variables' as v;
+@use '../../../../styles/mixins' as m;
 @use '../../shared/wizard-shared' as wizard;
 
 .step1-upload {
@@ -235,6 +236,7 @@
 
 .stat-content {
   flex: 1;
+  min-width: 0;
 }
 
 .stat-label {
@@ -247,6 +249,7 @@
   font-size: 14px;
   font-weight: 600;
   color: v.$gray-800;
+  @include m.text-truncate;
 }
 
 .profile-section {

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -80,7 +80,7 @@
             >
               <span class="material-icons drag-handle" title="Drag to reorder">drag_indicator</span>
               <span class="feature-order">{{ i + 1 }}</span>
-              <span class="feature-name">{{ feature }}</span>
+              <span class="feature-name" [title]="feature">{{ feature }}</span>
               @if (getFeatureVariance(feature) !== null) {
                 <span class="variance-bar" title="Relative variance: {{ getFeatureVariance(feature)?.toFixed(4) }}">
                   <span class="variance-fill" [style.width.%]="getFeatureVariancePercent(feature)"></span>
@@ -150,7 +150,7 @@
               (dragend)="onDragEnd($event)"
             >
               <span class="material-icons add-icon">add</span>
-              <span class="feature-name">{{ feature }}</span>
+              <span class="feature-name" [title]="feature">{{ feature }}</span>
               @if (getFeatureVariance(feature) !== null) {
                 <span class="variance-bar" title="Relative variance: {{ getFeatureVariance(feature)?.toFixed(4) }}">
                   <span class="variance-fill" [style.width.%]="getFeatureVariancePercent(feature)"></span>
@@ -359,7 +359,7 @@
                   [checked]="entry.config.includeInProjection"
                   (change)="toggleColumnProjection(entry.column.name)"
                 />
-                <span class="col-name">{{ entry.column.name }}</span>
+                <span class="col-name" [title]="entry.column.name">{{ entry.column.name }}</span>
                 <app-data-type-badge [dataType]="entry.column.dataType"></app-data-type-badge>
                 <button
                   type="button"

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -79,7 +79,14 @@
     .form-group {
       @include m.form-group;
 
-      select,
+      // Native select must read as a dropdown (chevron affordance), not a
+      // plain text input (C-S4-02).
+      select {
+        @include w.select;
+        width: 200px;
+        display: block;
+      }
+
       app-color-scale-selector {
         width: 200px;
         display: block;

--- a/src/styles/_mixins.scss
+++ b/src/styles/_mixins.scss
@@ -138,17 +138,20 @@
     border: 1px solid v.$ui-border-light;
     background: white;
 
+    // Match the native wizard <select> chevron (see the `select` mixin): the
+    // same solid triangle, colour and size, so every dropdown affordance in the
+    // wizard reads as identical.
     &::after {
       content: '';
       display: inline-block;
-      width: 16px;
-      height: 16px;
+      width: 12px;
+      height: 12px;
       margin-left: auto;
       flex-shrink: 0;
-      background-image: url("data:image/svg+xml;utf8,<svg fill='none' stroke='%23333' stroke-width='2' viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><path d='M6 9l6 6 6-6'/></svg>");
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%23666' d='M6 9L1 4h10z'/%3E%3C/svg%3E");
       background-repeat: no-repeat;
       background-position: center;
-      background-size: 16px 16px;
+      background-size: 12px 12px;
     }
 
     &:hover {


### PR DESCRIPTION
## Ticket A10 + A7 (gebündelt)

A10-Restumfang war nach A15/A9 klein, daher mit dem verwandten Polish-Ticket A7 zusammengefasst.

### A10 – Layout gegen lange Inhalte (P-S1-01, C-S4-11)
- Step 1: Dateiname in der Stat-Card kürzt jetzt per Ellipsis + zeigt vollen Namen als `[title]`, bricht nicht mehr aus dem Grid.
- Step 4: `[title]` an Feature- und Projektions-Spaltennamen (Konsistenz zu Step 2/3).
- Data-Preview-Tabelle: `[title]` an Header- und Zellnamen.

### A7 – Ehrliche Signifier (C-S1-01, C-S4-02, S-S2-01)
- Progress-Stepper: erreichbare Schritte in Akzent-Cyan statt ausgegraut (wirken nicht mehr deaktiviert).
- Step 4: COLOR-ATTRIBUTE-Feld als Select mit Chevron statt wie ein Texteingabefeld.
- Select-All (Step 2) war bereits korrekt (indeterminate/checked aus A9-Merge) – verifiziert, keine Änderung nötig.
- C-S3-03 bewusst ausgelassen (laut ROADMAP nach A1 verschoben, dort per Erklärtext).

### Manuelle Testschritte (Schritt → Location → Erwartung)
- Datei mit langem Namen hochladen → Step 1 Stat-Card → Ellipsis, voller Name im Tooltip, kein Layout-Bruch.
- Langer Feature-/Spaltenname → Step 4 → gekürzt, Hover zeigt vollen Namen.
- Langer Spalten-/Zellwert → Datenvorschau Step 1/2 → Hover zeigt vollen Wert.
- Beliebiger Schritt → Stepper → besuchte/erreichbare Schritte in Cyan, nur Zukunftsschritte grau.
- Step 4 → COLOR ATTRIBUTE → Dropdown-Chevron erkennbar.
- Step 2 einige Spalten wählen → Kopf-Checkbox indeterminate; alle → Haken; keine → leer.

Build: `npm run build` erfolgreich (nur vorbestehende Bundle-Budget-Warnung).
