### PR TITLE
feat(a3): Fehlermeldungen inline, verstaendlich, loesungsorientiert

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -116,7 +116,10 @@ Quick Wins ohne Abhängigkeit, die sich parallel zum Fundament wegräumen lassen
 **Wo umsetzen:**
 - Smart-Default-Logik/State in `services/preprocessing.service.ts` (Kennzeichnung „vom Default abweichend", Reset-Funktion).
 - Vorauswahl beim Spalten-Import in `steps/step2-column-selection/` (offensichtlich ungeeignete Spalten vorab abwählen; vgl. `missingPercentage > 50 || uniqueCount === 1`).
+- Vorauswahl erweitern um Hochkardinalität: Spalten mit (nahezu) 100 % Uniqueness (`uniqueCount === totalRows` bzw. `uniqueCount / totalRows` nahe 1 — typisch IDs, Titel, Namen, Freitext) beim Import automatisch abwählen, sichtbar gekennzeichnet und wie jeder Default umkehrbar. Ergänzt die bestehende Heuristik um den Fall, der bisher erst zur Laufzeit auffällt.
 - Sichtbare Kennzeichnung + „Smart Defaults zurücksetzen/erneut anwenden"-Button in `steps/step3-configure-data-features/` und `steps/step4-visualization-settings/`.
+
+**Bezug (aus A3 / Fehlerklasse K7):** In A3 wurde der *reaktive* Teil dieses Problems abgedeckt — der Prozessor bricht bei einer One-Hot-Explosion früh und verständlich ab (`src/assets/preprocessing_processor_config.py`, Schwelle `MAX_ONEHOT_UNIQUE`), und die Fehlerklasse K7 (`shared/constants/wizard-error-classes.ts`) benennt die betroffenen Spalten und schlägt Abwählen bzw. Label-Encoding vor. Konkreter Auslöser war `streaming_titles.csv` mit fünf pro Zeile einzigartigen Spalten (`show_id`, `title`, `director`, `cast`, `description`): One-Hot hätte daraus ~43.750 Spalten erzeugt und den (Pyodide-)Speicher gesprengt. A2 soll denselben Fall *proaktiv* entschärfen — solche Spalten gar nicht erst standardmäßig aktiv lassen, statt den Nutzer erst im Fehlerfall (K7) gegensteuern zu lassen.
 
 ---
 

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.html
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.html
@@ -24,16 +24,6 @@
 
     <div class="wizard-main">
       <div class="wizard-content" #wizardContent>
-        @if (error) {
-          <div class="error-banner">
-            <span class="material-icons">error</span>
-            <span>{{ error }}</span>
-            <button class="btn-close" (click)="error = null">
-              <span class="material-icons">close</span>
-            </button>
-          </div>
-        }
-
         <div class="step-container">
           @switch (currentStep) {
             @case (0) {

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.ts
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.ts
@@ -39,7 +39,6 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
   currentStep = 0;
   highestStepVisited = 0; // Track highest step to enable forward navigation
   isProcessing = false;
-  error: string | null = null;
 
   // Labels and descriptions come from STEP_INFO so the sidebar stays the single
   // source of truth for step titles/purposes (no duplication in the work area).
@@ -60,7 +59,6 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
       this.preprocessingService.state$.subscribe(state => {
         this.currentStep = state.currentStep;
         this.isProcessing = state.isProcessing;
-        this.error = state.error;
 
         // Track highest step visited for navigation
         if (state.currentStep > this.highestStepVisited) {

--- a/src/app/preprocessing-wizard/services/preprocessing.service.spec.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.spec.ts
@@ -1,0 +1,74 @@
+import { PreprocessingService } from './preprocessing.service';
+import { DataProcessorService } from '../../services/data-processor';
+import { DataLoaderService } from '../../services/data-loader.service';
+
+/**
+ * A3 — state-level error-handling tests for PreprocessingService.
+ * `toErrorMessage` must keep string rejections (the worker often rejects with a
+ * plain string, which the old `instanceof Error` check discarded), and
+ * `clearError` must clear the lingering error flag so a stale "Processing
+ * failed" no longer survives closing/reopening the wizard.
+ *
+ * The service is constructed directly with lightweight stubs to avoid pulling
+ * the heavy data-processor / pyodide runtime into the unit test.
+ */
+describe('PreprocessingService — error handling (A3)', () => {
+  let service: PreprocessingService;
+
+  beforeEach(() => {
+    localStorage.removeItem('glyphspace_preprocessing_state');
+    const dataProcessor = {} as unknown as DataProcessorService;
+    const dataLoader = { getDataSetNames: () => [] } as unknown as DataLoaderService;
+    service = new PreprocessingService(dataProcessor, dataLoader);
+  });
+
+  describe('toErrorMessage', () => {
+    // Private helper — accessed via bracket notation for the unit test.
+    const call = (err: unknown, fallback: string): string =>
+      (service as unknown as { toErrorMessage(e: unknown, f: string): string }).toErrorMessage(err, fallback);
+
+    it('returns the message of an Error instance', () => {
+      expect(call(new Error('worker exploded'), 'fallback')).toBe('worker exploded');
+    });
+
+    it('keeps a non-empty string rejection instead of discarding it', () => {
+      expect(call('could not convert string to float', 'fallback')).toBe('could not convert string to float');
+    });
+
+    it('falls back for an empty / whitespace-only string', () => {
+      expect(call('   ', 'Processing failed')).toBe('Processing failed');
+      expect(call('', 'Processing failed')).toBe('Processing failed');
+    });
+
+    it('falls back for non-string, non-Error values', () => {
+      expect(call({ some: 'object' }, 'Processing failed')).toBe('Processing failed');
+      expect(call(null, 'Processing failed')).toBe('Processing failed');
+      expect(call(undefined, 'Processing failed')).toBe('Processing failed');
+    });
+  });
+
+  describe('clearError', () => {
+    // Seed an error into the singleton state via the private updateState.
+    const setError = (msg: string | null): void =>
+      (service as unknown as { updateState(u: { error: string | null }): void }).updateState({ error: msg });
+
+    it('clears a lingering processing error from the state', () => {
+      setError('Processing failed');
+      expect(service.currentState.error).toBe('Processing failed');
+
+      service.clearError();
+      expect(service.currentState.error).toBeNull();
+    });
+
+    it('is a no-op when there is no error', () => {
+      let emissions = 0;
+      service.state$.subscribe(() => emissions++);
+      const before = emissions; // includes the initial replay emission
+
+      service.clearError();
+      expect(service.currentState.error).toBeNull();
+      // No error present → no extra state emission.
+      expect(emissions).toBe(before);
+    });
+  });
+});

--- a/src/app/preprocessing-wizard/services/preprocessing.service.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.ts
@@ -168,7 +168,7 @@ export class PreprocessingService {
     } catch (error: unknown) {
       this.updateState({
         isProcessing: false,
-        error: error instanceof Error ? error.message : 'Failed to load data file',
+        error: this.toErrorMessage(error, 'Failed to load data file'),
       });
       throw error;
     }
@@ -449,9 +449,27 @@ export class PreprocessingService {
     } catch (error: unknown) {
       this.updateState({
         isProcessing: false,
-        error: error instanceof Error ? error.message : 'Processing failed',
+        error: this.toErrorMessage(error, 'Processing failed'),
       });
       throw error;
+    }
+  }
+
+  /** Extract a human-readable message from an unknown thrown value without
+   *  discarding string rejections (the old `instanceof Error` check dropped
+   *  the real worker cause and fell back to a generic string). */
+  private toErrorMessage(error: unknown, fallback: string): string {
+    if (error instanceof Error) return error.message;
+    if (typeof error === 'string' && error.trim().length > 0) return error;
+    return fallback;
+  }
+
+  /** Clear a lingering processing error. The error flag lives in the root
+   *  singleton state and previously survived closing/reopening the wizard,
+   *  so a stale "Processing failed" reappeared on re-entry (P-S5-03). */
+  public clearError(): void {
+    if (this.currentState.error !== null) {
+      this.updateState({ error: null });
     }
   }
 

--- a/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.spec.ts
+++ b/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.spec.ts
@@ -1,0 +1,304 @@
+import {
+  classifyProcessingError,
+  classifyBackgroundFailure,
+  detectPreflightIssues,
+  WizardIssue,
+} from './wizard-error-classes';
+import { PreprocessingState } from '../../models/preprocessing-state';
+import { ColumnConfig } from '../../models/column-config';
+import { ColumnStatistics, DataProfile } from '../../models/column-statistics';
+import {
+  DataType,
+  EncodingMethod,
+  ScalingMethod,
+  MissingValueStrategy,
+  OutlierStrategy,
+  OutlierMethod,
+} from '../../models/data-type.enum';
+
+/**
+ * A3 — unit tests for the error-classification and pre-flight-detection logic.
+ * Covers the six user-relevant failure classes (K1–K6), the generic fallback,
+ * background (partial) failures and state-derived pre-flight warnings.
+ */
+
+// A structured issue must always be actionable: cause and fix are present and
+// never leak the raw text into the user-facing title.
+function expectActionable(issue: WizardIssue, raw?: string): void {
+  expect(issue.title.trim().length).toBeGreaterThan(0);
+  expect(issue.why.trim().length).toBeGreaterThan(0);
+  expect(issue.fix.trim().length).toBeGreaterThan(0);
+  if (raw) {
+    expect(issue.title).not.toContain(raw);
+  }
+}
+
+describe('classifyProcessingError', () => {
+  // One representative raw message per class → expected code, step and anchor.
+  const cases: { name: string; raw: string; code: string; step: number; anchorId: string }[] = [
+    {
+      name: 'K1 — non-numeric value in a projection column',
+      raw: 'ValueError: could not convert string to float: "abc"',
+      code: 'K1',
+      step: 2,
+      anchorId: 'wizard-anchor-columns',
+    },
+    {
+      name: 'K2 — no rows left after cleaning',
+      raw: 'No data rows remaining after cleaning (0 rows)',
+      code: 'K2',
+      step: 2,
+      anchorId: 'wizard-anchor-columns',
+    },
+    {
+      name: 'K3 — column with no variance',
+      raw: 'Column has zero variance / constant value',
+      code: 'K3',
+      step: 1,
+      anchorId: 'wizard-anchor-columns',
+    },
+    {
+      name: 'K4 — neighbour parameter out of range',
+      raw: 'n_neighbors=50 must be greater than 1 and less than n_samples=10',
+      code: 'K4',
+      step: 3,
+      anchorId: 'wizard-anchor-methods',
+    },
+    {
+      name: 'K5 — glyph feature count out of range',
+      raw: 'A glyph needs 3-12 glyph features',
+      code: 'K5',
+      step: 3,
+      anchorId: 'wizard-anchor-glyph',
+    },
+    {
+      name: 'K6 — time / resource limit',
+      raw: 'Worker aborted: computation timed out',
+      code: 'K6',
+      step: 3,
+      anchorId: 'wizard-anchor-methods',
+    },
+  ];
+
+  cases.forEach(c => {
+    it(`classifies ${c.name}`, () => {
+      const issue = classifyProcessingError(c.raw);
+      expect(issue.code).toBe(c.code);
+      expect(issue.severity).toBe('blocking');
+      expect(issue.step).toBe(c.step);
+      expect(issue.anchorId).toBe(c.anchorId);
+      expect(issue.raw).toBe(c.raw);
+      expectActionable(issue, c.raw);
+    });
+  });
+
+  it('is case-insensitive on the raw message', () => {
+    expect(classifyProcessingError('COULD NOT CONVERT STRING to float').code).toBe('K1');
+    expect(classifyProcessingError('Out Of Memory').code).toBe('K6');
+  });
+
+  it('falls back to a generic, still-actionable blocking issue for unmatched errors', () => {
+    const raw = 'Segfault 0xDEADBEEF in libfoo.so at frame #7';
+    const issue = classifyProcessingError(raw);
+    expect(issue.code).toBe('');
+    expect(issue.severity).toBe('blocking');
+    // The user-facing title must not be the raw technical text.
+    expect(issue.title).not.toContain('Segfault');
+    expect(issue.title).not.toContain('0xDEADBEEF');
+    // But the raw text is preserved for the collapsible technical section.
+    expect(issue.raw).toBe(raw);
+    expectActionable(issue, raw);
+  });
+
+  it('handles empty / nullish input without throwing', () => {
+    const issue = classifyProcessingError('');
+    expect(issue.code).toBe('');
+    expectActionable(issue);
+    expect(classifyProcessingError(undefined as unknown as string).code).toBe('');
+  });
+});
+
+describe('classifyBackgroundFailure', () => {
+  it('produces a dismissable warning that names the method and keeps raw detail', () => {
+    const issue = classifyBackgroundFailure('umap', 'n_neighbors too large for n_samples');
+    expect(issue.severity).toBe('warning');
+    expect(issue.dismissable).toBe(true);
+    expect(issue.title).toContain('UMAP');
+    expect(issue.raw).toBe('n_neighbors too large for n_samples');
+    // Cause/fix are inherited from the underlying classification (K4 here).
+    expect(issue.code).toBe('K4');
+    expectActionable(issue);
+  });
+
+  it('supplies a synthetic raw detail when none is given', () => {
+    const issue = classifyBackgroundFailure('tsne');
+    expect(issue.raw).toContain('tsne');
+    expect(issue.severity).toBe('warning');
+    expect(issue.dismissable).toBe(true);
+  });
+});
+
+// ---- Fixtures for detectPreflightIssues ----------------------------------
+
+function makeColumnStats(overrides: Partial<ColumnStatistics>): ColumnStatistics {
+  return {
+    name: 'col',
+    dataType: DataType.Numeric,
+    count: 100,
+    missingCount: 0,
+    missingPercentage: 0,
+    uniqueCount: 50,
+    ...overrides,
+  };
+}
+
+function makeColumnConfig(overrides: Partial<ColumnConfig>): ColumnConfig {
+  return {
+    name: 'col',
+    originalType: DataType.Numeric,
+    targetType: DataType.Numeric,
+    encodingMethod: EncodingMethod.None,
+    scalingMethod: ScalingMethod.None,
+    includeInProjection: true,
+    isColorFeature: false,
+    missingValueStrategy: MissingValueStrategy.Keep,
+    outlierMethod: OutlierMethod.IQR_1_5,
+    outlierStrategy: OutlierStrategy.Keep,
+    enabled: true,
+    hasIssues: false,
+    ...overrides,
+  } as ColumnConfig;
+}
+
+function makeState(opts: {
+  totalRows: number;
+  columns: ColumnStatistics[];
+  configs: ColumnConfig[];
+  projection?: Partial<PreprocessingState['projectionConfig']>;
+}): PreprocessingState {
+  const profile: DataProfile = {
+    totalRows: opts.totalRows,
+    totalColumns: opts.columns.length,
+    fileSize: 1000,
+    fileName: 'test.csv',
+    columns: opts.columns,
+    qualityScore: 1,
+    duplicateCount: 0,
+    previewRows: [],
+  };
+  const columnConfigs = new Map<string, ColumnConfig>();
+  opts.configs.forEach(c => columnConfigs.set(c.name, c));
+  const baseProjection = {
+    enablePCA: false,
+    enableIsoMap: false,
+    enableMDS: false,
+    enableLLE: false,
+    enableLTSA: false,
+    enableTSNE: false,
+    enableUMAP: false,
+    enableTriMap: false,
+    enableTopoMap: false,
+    enableSammon: false,
+    isomapNeighbors: 0,
+    lleNeighbors: 0,
+    ltsaNeighbors: 0,
+    tsnePerplexity: 30,
+    tsneIterations: 1000,
+    umapNeighbors: 15,
+    umapMinDist: 0.1,
+    trimapWeightAdj: 500,
+  };
+  return {
+    dataProfile: profile,
+    columnConfigs,
+    projectionConfig: { ...baseProjection, ...(opts.projection ?? {}) },
+  } as unknown as PreprocessingState;
+}
+
+describe('detectPreflightIssues', () => {
+  it('returns nothing when there is no data profile', () => {
+    const state = { dataProfile: null } as unknown as PreprocessingState;
+    expect(detectPreflightIssues(state)).toEqual([]);
+  });
+
+  it('flags a constant projection column as a K3 warning (step 2)', () => {
+    const state = makeState({
+      totalRows: 100,
+      columns: [makeColumnStats({ name: 'const', uniqueCount: 1 })],
+      configs: [makeColumnConfig({ name: 'const' })],
+    });
+    const issues = detectPreflightIssues(state);
+    const k3 = issues.find(i => i.code === 'K3');
+    expect(k3).toBeTruthy();
+    expect(k3!.severity).toBe('warning');
+    expect(k3!.step).toBe(1);
+    expect(k3!.title).toContain('const');
+    expectActionable(k3!);
+  });
+
+  it('flags a mostly-empty projection column as a K3 warning', () => {
+    const state = makeState({
+      totalRows: 100,
+      columns: [makeColumnStats({ name: 'sparse', missingPercentage: 80 })],
+      configs: [makeColumnConfig({ name: 'sparse' })],
+    });
+    expect(detectPreflightIssues(state).some(i => i.code === 'K3')).toBe(true);
+  });
+
+  it('ignores bad columns that are not selected for the projection', () => {
+    const state = makeState({
+      totalRows: 100,
+      columns: [makeColumnStats({ name: 'const', uniqueCount: 1 })],
+      configs: [makeColumnConfig({ name: 'const', includeInProjection: false })],
+    });
+    expect(detectPreflightIssues(state).some(i => i.code === 'K3')).toBe(false);
+  });
+
+  it('flags a neighbour count >= row count as a K4 warning (step 4)', () => {
+    const state = makeState({
+      totalRows: 10,
+      columns: [makeColumnStats({ name: 'a' })],
+      configs: [makeColumnConfig({ name: 'a' })],
+      projection: { enableUMAP: true, umapNeighbors: 15 },
+    });
+    const k4 = detectPreflightIssues(state).find(i => i.code === 'K4');
+    expect(k4).toBeTruthy();
+    expect(k4!.severity).toBe('warning');
+    expect(k4!.step).toBe(3);
+    expect(k4!.why).toContain('UMAP');
+    expectActionable(k4!);
+  });
+
+  it('does not flag K4 when the neighbour count stays below the row count', () => {
+    const state = makeState({
+      totalRows: 100,
+      columns: [makeColumnStats({ name: 'a' })],
+      configs: [makeColumnConfig({ name: 'a' })],
+      projection: { enableUMAP: true, umapNeighbors: 15 },
+    });
+    expect(detectPreflightIssues(state).some(i => i.code === 'K4')).toBe(false);
+  });
+
+  it('flags a slow method on a large dataset as a K6 warning', () => {
+    const state = makeState({
+      totalRows: 20000,
+      columns: [makeColumnStats({ name: 'a' })],
+      configs: [makeColumnConfig({ name: 'a' })],
+      projection: { enableTSNE: true },
+    });
+    const k6 = detectPreflightIssues(state).find(i => i.code === 'K6');
+    expect(k6).toBeTruthy();
+    expect(k6!.severity).toBe('warning');
+    expectActionable(k6!);
+  });
+
+  it('does not flag K6 for a large dataset with only fast methods', () => {
+    const state = makeState({
+      totalRows: 20000,
+      columns: [makeColumnStats({ name: 'a' })],
+      configs: [makeColumnConfig({ name: 'a' })],
+      projection: { enablePCA: true },
+    });
+    expect(detectPreflightIssues(state).some(i => i.code === 'K6')).toBe(false);
+  });
+});

--- a/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.spec.ts
+++ b/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.spec.ts
@@ -18,7 +18,7 @@ import {
 
 /**
  * A3 — unit tests for the error-classification and pre-flight-detection logic.
- * Covers the six user-relevant failure classes (K1–K6), the generic fallback,
+ * Covers the user-relevant failure classes (K1–K7), the generic fallback,
  * background (partial) failures and state-derived pre-flight warnings.
  */
 
@@ -78,6 +78,13 @@ describe('classifyProcessingError', () => {
       step: 3,
       anchorId: 'wizard-anchor-methods',
     },
+    {
+      name: 'K7 — column with too many distinct values (one-hot explosion)',
+      raw: "These columns have too many distinct values to one-hot encode: 'title' (9000 distinct values).",
+      code: 'K7',
+      step: 1,
+      anchorId: 'wizard-anchor-columns',
+    },
   ];
 
   cases.forEach(c => {
@@ -95,6 +102,36 @@ describe('classifyProcessingError', () => {
   it('is case-insensitive on the raw message', () => {
     expect(classifyProcessingError('COULD NOT CONVERT STRING to float').code).toBe('K1');
     expect(classifyProcessingError('Out Of Memory').code).toBe('K6');
+  });
+
+  it('K7 names the offending column and wins over the generic memory class', () => {
+    const raw =
+      "Failed to process data: These columns have too many distinct values to one-hot encode: " +
+      "'title' (9000 distinct values). Each would expand into that many feature columns, which " +
+      "exceeds the in-browser memory. Deselect them in the column step, or switch their encoding to label.";
+    const issue = classifyProcessingError(raw);
+    // Even though the raw mentions "memory" (would match K6), the more specific
+    // K7 is checked first and wins.
+    expect(issue.code).toBe('K7');
+    expect(issue.step).toBe(1);
+    expect(issue.anchorId).toBe('wizard-anchor-columns');
+    expect(issue.title).toContain('title');
+    expect(issue.why).toContain('title');
+    expect(issue.why).toContain('9000');
+    expectActionable(issue, raw);
+  });
+
+  it('K7 lists every offending column when several are near-unique', () => {
+    const raw =
+      "These columns have too many distinct values to one-hot encode: " +
+      "'show_id' (9000 distinct values), 'title' (9000 distinct values), 'cast' (8281 distinct values).";
+    const issue = classifyProcessingError(raw);
+    expect(issue.code).toBe('K7');
+    expect(issue.title).toContain('3 columns');
+    expect(issue.why).toContain('show_id');
+    expect(issue.why).toContain('title');
+    expect(issue.why).toContain('cast');
+    expectActionable(issue, raw);
   });
 
   it('falls back to a generic, still-actionable blocking issue for unmatched errors', () => {

--- a/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.ts
+++ b/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.ts
@@ -103,6 +103,15 @@ const CLASS_TEMPLATES: Record<string, Omit<WizardIssue, 'raw'>> = {
     step: 3,
     anchorId: 'wizard-anchor-methods',
   },
+  K7: {
+    code: 'K7',
+    severity: 'blocking',
+    title: 'A column has too many distinct values to encode',
+    why: 'A selected text column has almost as many different values as there are rows (typical of an ID, title, name or free-text field). Encoding it would expand the data into thousands of columns — more than the in-browser engine can hold in memory.',
+    fix: 'Deselect that column in Step 2 (Select Columns), or set its encoding to Label in Step 3 (Configure Data & Features).',
+    step: 1,
+    anchorId: 'wizard-anchor-columns',
+  },
 };
 
 function template(code: string): WizardIssue {
@@ -118,7 +127,20 @@ export function classifyProcessingError(raw: string): WizardIssue {
   const msg = (raw || '').toLowerCase();
   let issue: WizardIssue;
 
-  if (/timed out|timeout|out of memory|memory|aborted/.test(msg)) {
+  if (/too many distinct values to one-?hot encode/.test(msg)) {
+    // K7 must be checked before K6: the underlying failure is a memory error,
+    // but the specific cause (a near-unique column blown up by one-hot) has a
+    // much more actionable fix than the generic "resource limit" advice.
+    issue = template('K7');
+    const pairs = [...raw.matchAll(/'([^']+)' \((\d+) distinct values\)/g)].map(m => `${m[1]} (${m[2]})`);
+    if (pairs.length === 1) {
+      issue.title = `The column ${pairs[0]} has too many distinct values`;
+      issue.why = `This column has almost as many different values as there are rows (typical of an ID, title, name or free-text field): ${pairs[0]}. Encoding it would expand the data into that many columns — more than the in-browser engine can hold in memory.`;
+    } else if (pairs.length > 1) {
+      issue.title = `${pairs.length} columns have too many distinct values`;
+      issue.why = `These columns have almost as many different values as there are rows (typical of IDs, titles, names or free-text): ${pairs.join(', ')}. Encoding them would expand the data into thousands of columns — more than the in-browser engine can hold in memory.`;
+    }
+  } else if (/timed out|timeout|out of memory|memory|aborted/.test(msg)) {
     issue = template('K6');
   } else if (/invalid numeric value|could not convert|non-?numeric|not a number|isnan|convert string/.test(msg)) {
     issue = template('K1');

--- a/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.ts
+++ b/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.ts
@@ -1,0 +1,239 @@
+/**
+ * Wizard error classes (A3).
+ *
+ * The six user-relevant failure classes are derivable from the code, but today
+ * the raw message that reaches the UI rarely makes the class obvious (see the
+ * analysis docs "fehlerklassen-ableitbarkeit" / "fehlerbehandlung-wizard-analyse").
+ * This module turns raw error strings — and pre-flight state signals — into
+ * structured issues that name the likely cause (WHY), the concrete action
+ * (FIX) and the exact wizard step that resolves it.
+ *
+ * The `step` index is 0-based (0=Upload … 4=Review); the displayed "Schritt N"
+ * is `step + 1`. `anchorId` reuses the A6 deep-link anchors so the "Fix in
+ * Schritt N" button jumps straight to the responsible control.
+ */
+
+import { PreprocessingState } from '../../models/preprocessing-state';
+import { ProjectionConfig } from '../../models/column-config';
+
+export type IssueSeverity = 'blocking' | 'warning';
+
+export interface WizardIssue {
+  /** Error-class code, e.g. "K1". Empty for unclassified/generic issues. */
+  code: string;
+  severity: IssueSeverity;
+  /** Everyday-language title (what went wrong). */
+  title: string;
+  /** WHY — the likely cause in plain language. */
+  why: string;
+  /** FIX — the concrete action, naming the step. */
+  fix: string;
+  /** 0-based target step index (goToStep / goToStepWithScroll). */
+  step: number;
+  /** A6 deep-link anchor id inside the target step (optional). */
+  anchorId?: string;
+  /** Raw technical detail, shown collapsed under "Technical details". */
+  raw?: string;
+  /** Whether the user may dismiss this issue (partial/optional failures). */
+  dismissable?: boolean;
+}
+
+/** English step titles, aligned with STEP_INFO, for the "Fix in Schritt N · <name>" button. */
+export const STEP_NAMES: Record<number, string> = {
+  0: 'Upload Data',
+  1: 'Select Columns',
+  2: 'Configure Data & Features',
+  3: 'Visualization Settings',
+  4: 'Review & Process',
+};
+
+/** Static class templates. Cause/fix/step are fixed per class; `raw`/`title` may be enriched. */
+const CLASS_TEMPLATES: Record<string, Omit<WizardIssue, 'raw'>> = {
+  K1: {
+    code: 'K1',
+    severity: 'blocking',
+    title: 'A projection column still contains text values',
+    why: 'Text or categorical values without a matching encoding ended up in the feature matrix, so the numeric projection cannot use them.',
+    fix: 'Set an encoding for that column, or remove it from the projection, in Step 3 (Configure Data & Features).',
+    step: 2,
+    anchorId: 'wizard-anchor-columns',
+  },
+  K2: {
+    code: 'K2',
+    severity: 'blocking',
+    title: 'No rows were left after cleaning',
+    why: 'The missing-value, outlier or duplicate rules were strict enough to remove every row.',
+    fix: 'Loosen the cleaning rules in Step 3 (Configure Data & Features) so some rows survive.',
+    step: 2,
+    anchorId: 'wizard-anchor-columns',
+  },
+  K3: {
+    code: 'K3',
+    severity: 'blocking',
+    title: 'A column has no usable values',
+    why: 'A selected column is constant or almost entirely empty, so scaling and projection have nothing to work with.',
+    fix: 'Deselect the affected column in Step 2 (Select Columns).',
+    step: 1,
+    anchorId: 'wizard-anchor-columns',
+  },
+  K4: {
+    code: 'K4',
+    severity: 'blocking',
+    title: 'A projection parameter is out of range',
+    why: 'The neighbour count is larger than the number of samples (IsoMap, LLE, LTSA or UMAP), which the method cannot compute.',
+    fix: 'Lower the parameter or disable the method in Step 4 (Visualization Settings).',
+    step: 3,
+    anchorId: 'wizard-anchor-methods',
+  },
+  K5: {
+    code: 'K5',
+    severity: 'blocking',
+    title: 'The number of glyph features is out of range',
+    why: 'A glyph needs between 3 and 12 features; the current selection is outside that range.',
+    fix: 'Adjust the selection to 3–12 features in Step 4 (Visualization Settings).',
+    step: 3,
+    anchorId: 'wizard-anchor-glyph',
+  },
+  K6: {
+    code: 'K6',
+    severity: 'blocking',
+    title: 'Processing hit a time or resource limit',
+    why: 'The dataset is large enough to exceed the worker time limit or available memory.',
+    fix: 'Reduce the dataset in Step 2, or reduce the number of methods in Step 4.',
+    step: 3,
+    anchorId: 'wizard-anchor-methods',
+  },
+};
+
+function template(code: string): WizardIssue {
+  return { ...CLASS_TEMPLATES[code] };
+}
+
+/**
+ * Classify a raw processing error message into one of the six classes.
+ * Falls back to a generic (still persistent, still actionable) blocking issue
+ * when no pattern matches, so the user never sees a bare "Processing failed".
+ */
+export function classifyProcessingError(raw: string): WizardIssue {
+  const msg = (raw || '').toLowerCase();
+  let issue: WizardIssue;
+
+  if (/timed out|timeout|out of memory|memory|aborted/.test(msg)) {
+    issue = template('K6');
+  } else if (/invalid numeric value|could not convert|non-?numeric|not a number|isnan|convert string/.test(msg)) {
+    issue = template('K1');
+  } else if (/empty|no valid feature data|no data rows|0 rows|no rows|nothing left/.test(msg)) {
+    issue = template('K2');
+  } else if (/neighbor|n_neighbors|perplexity|k must|greater than|exceeds|out of range|sample/.test(msg)) {
+    issue = template('K4');
+  } else if (/glyph feature|3-12|3 to 12/.test(msg)) {
+    issue = template('K5');
+  } else if (/constant|zero variance|no variance|all missing|singular|division by zero/.test(msg)) {
+    issue = template('K3');
+  } else {
+    issue = {
+      code: '',
+      severity: 'blocking',
+      title: "We couldn't finish processing your data",
+      why: 'The exact cause was reported by the processing engine (see technical details below).',
+      fix: 'Review your column and method settings, then start processing again. If it keeps failing, remove the most complex methods in Step 4.',
+      step: 3,
+      anchorId: 'wizard-anchor-methods',
+    };
+  }
+
+  issue.raw = raw;
+  return issue;
+}
+
+/**
+ * Classify a background (non-primary) projection failure into a dismissable
+ * warning. FastMap already succeeded, so the visualization is usable — this is
+ * a degraded/partial state, not a hard failure.
+ */
+export function classifyBackgroundFailure(method: string, raw?: string): WizardIssue {
+  const base = classifyProcessingError(raw || '');
+  return {
+    ...base,
+    severity: 'warning',
+    dismissable: true,
+    title: `${method.toUpperCase()} could not be computed`,
+    raw: raw || `${method} failed`,
+  };
+}
+
+/**
+ * Pre-flight detection: read signals already present in the state to warn about
+ * likely failures BEFORE processing starts. These use the same signals the
+ * profiler already computes (hasIssues = constant/mostly-missing column) plus
+ * derivable parameter/size checks. Returned as "possible issue" warnings.
+ */
+export function detectPreflightIssues(state: PreprocessingState): WizardIssue[] {
+  const issues: WizardIssue[] = [];
+  const profile = state.dataProfile;
+  if (!profile) return issues;
+
+  const rowCount = profile.totalRows ?? 0;
+
+  // K3 — constant / mostly-empty columns that are still selected for the projection.
+  const badColumns: string[] = [];
+  state.columnConfigs.forEach(config => {
+    if (!config.enabled || !config.includeInProjection) return;
+    const col = profile.columns.find(c => c.name === config.name);
+    if (!col) return;
+    if (col.uniqueCount === 1 || col.missingPercentage > 50) {
+      badColumns.push(config.name);
+    }
+  });
+  if (badColumns.length > 0) {
+    const t = template('K3');
+    issues.push({
+      ...t,
+      severity: 'warning',
+      title:
+        badColumns.length === 1
+          ? `Column "${badColumns[0]}" may have no usable values`
+          : `${badColumns.length} projection columns may have no usable values`,
+      why: `These columns are constant or mostly empty: ${badColumns.join(', ')}. They add no information and can make the projection fail.`,
+      raw: `Flagged by profiling (uniqueCount === 1 || missingPercentage > 50): ${badColumns.join(', ')}`,
+    });
+  }
+
+  // K4 — neighbour parameters larger than the sample size.
+  const pc: ProjectionConfig = state.projectionConfig;
+  const neighborChecks: { enabled: boolean; label: string; value: number }[] = [
+    { enabled: pc.enableIsoMap, label: 'IsoMap', value: pc.isomapNeighbors },
+    { enabled: pc.enableLLE, label: 'LLE', value: pc.lleNeighbors },
+    { enabled: pc.enableLTSA, label: 'LTSA', value: pc.ltsaNeighbors },
+    { enabled: pc.enableUMAP, label: 'UMAP', value: pc.umapNeighbors },
+  ];
+  const offending = neighborChecks.filter(c => c.enabled && c.value > 0 && rowCount > 0 && c.value >= rowCount);
+  if (offending.length > 0) {
+    const t = template('K4');
+    issues.push({
+      ...t,
+      severity: 'warning',
+      title: 'A method needs more neighbours than you have rows',
+      why: `${offending
+        .map(o => `${o.label} (neighbours ${o.value})`)
+        .join(', ')} — the neighbour count must stay below the row count (${rowCount}).`,
+      raw: `rowCount=${rowCount}; ${offending.map(o => `${o.label}.neighbors=${o.value}`).join(', ')}`,
+    });
+  }
+
+  // K6 — large dataset combined with a slow method risks the worker time limit.
+  const SLOW_LIMIT = 15000;
+  const slowEnabled = pc.enableTSNE || pc.enableSammon || pc.enableUMAP;
+  if (rowCount > SLOW_LIMIT && slowEnabled) {
+    const t = template('K6');
+    issues.push({
+      ...t,
+      severity: 'warning',
+      title: 'A slow method on a large dataset may time out',
+      why: `The dataset has ${rowCount.toLocaleString()} rows and a slow method (t-SNE, Sammon or UMAP) is enabled, which can exceed the processing time limit.`,
+      raw: `rowCount=${rowCount}; slow methods enabled.`,
+    });
+  }
+
+  return issues;
+}

--- a/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.ts
+++ b/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.ts
@@ -135,8 +135,8 @@ export function classifyProcessingError(raw: string): WizardIssue {
       code: '',
       severity: 'blocking',
       title: "We couldn't finish processing your data",
-      why: 'The exact cause was reported by the processing engine (see technical details below).',
-      fix: 'Review your column and method settings, then start processing again. If it keeps failing, remove the most complex methods in Step 4.',
+      why: 'Something in the current combination of columns, cleaning rules and methods stopped the projection from finishing. This is almost always a settings issue, not a problem with your data — and your upload and settings are still here.',
+      fix: 'Start processing again. If it keeps failing, deselect any text-heavy or mostly-empty columns in Step 2, then turn off the more advanced methods (t-SNE, UMAP, Sammon) in Step 4 and try once more.',
       step: 3,
       anchorId: 'wizard-anchor-methods',
     };

--- a/src/app/preprocessing-wizard/shared/wizard-issue-card/wizard-issue-card.component.html
+++ b/src/app/preprocessing-wizard/shared/wizard-issue-card/wizard-issue-card.component.html
@@ -1,0 +1,43 @@
+<div class="issue-card" [class.blocking]="issue.severity === 'blocking'" [class.warning]="issue.severity === 'warning'">
+  <div class="issue-head">
+    <span class="severity-icon material-icons">
+      {{ issue.severity === 'blocking' ? 'error' : 'warning' }}
+    </span>
+    @if (issue.code) {
+      <span class="class-badge">{{ issue.code }}</span>
+    }
+    <span class="issue-title">{{ issue.title }}</span>
+    <span class="severity-pill">{{ pillLabel }}</span>
+  </div>
+
+  <div class="issue-grid">
+    <div class="grid-row">
+      <span class="grid-key">WHY</span>
+      <span class="grid-val">{{ issue.why }}</span>
+    </div>
+    <div class="grid-row">
+      <span class="grid-key">FIX</span>
+      <span class="grid-val">{{ issue.fix }}</span>
+    </div>
+  </div>
+
+  @if (issue.raw) {
+    <button type="button" class="technical-toggle" (click)="toggleTechnical()">
+      <span class="material-icons">{{ technicalOpen ? 'expand_less' : 'expand_more' }}</span>
+      {{ technicalOpen ? 'Hide technical details' : 'Technical details' }}
+    </button>
+    @if (technicalOpen) {
+      <pre class="technical-detail">{{ issue.raw }}</pre>
+    }
+  }
+
+  <div class="issue-actions">
+    <button type="button" class="btn-fix" (click)="fix.emit(issue)">
+      Fix in Schritt {{ stepNumber }} · {{ stepName }}
+      <span class="material-icons">arrow_forward</span>
+    </button>
+    @if (issue.dismissable) {
+      <button type="button" class="btn-dismiss" (click)="dismiss.emit(issue)">Dismiss</button>
+    }
+  </div>
+</div>

--- a/src/app/preprocessing-wizard/shared/wizard-issue-card/wizard-issue-card.component.scss
+++ b/src/app/preprocessing-wizard/shared/wizard-issue-card/wizard-issue-card.component.scss
@@ -1,0 +1,192 @@
+@use '../../../../styles/variables' as v;
+
+.issue-card {
+  border: 1px solid v.$gray-300;
+  border-radius: 6px;
+  padding: 14px 16px;
+  background: white;
+
+  // Blocking / hard failure (design palette, aligned to $status-error family).
+  &.blocking {
+    background: #fffafa;
+    border-color: #f0d3cf;
+
+    .severity-icon {
+      color: #d64541;
+    }
+
+    .class-badge {
+      background: #fbe0de;
+      color: #b3261e;
+    }
+  }
+
+  // Warning / degraded or possible issue (aligned to $status-warning family).
+  &.warning {
+    background: #fffdf9;
+    border-color: #f2dcb6;
+
+    .severity-icon {
+      color: #d08a1e;
+    }
+
+    .class-badge {
+      background: #ffe8c9;
+      color: #a4670f;
+    }
+  }
+
+  .issue-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 10px;
+
+    .severity-icon {
+      font-size: 20px;
+      flex-shrink: 0;
+    }
+
+    .class-badge {
+      font-family: 'Roboto Mono', 'Courier New', monospace;
+      font-size: 11px;
+      font-weight: 700;
+      padding: 2px 6px;
+      border-radius: 4px;
+      flex-shrink: 0;
+    }
+
+    .issue-title {
+      font-size: 14px;
+      font-weight: 600;
+      color: v.$gray-800;
+      flex: 1;
+    }
+
+    .severity-pill {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.02em;
+      color: v.$gray-600;
+      background: v.$gray-100;
+      border: 1px solid v.$gray-300;
+      border-radius: 10px;
+      padding: 2px 8px;
+      flex-shrink: 0;
+    }
+  }
+
+  .issue-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+
+    .grid-row {
+      display: grid;
+      grid-template-columns: 44px 1fr;
+      gap: 10px;
+      align-items: start;
+
+      .grid-key {
+        font-size: 10px;
+        font-weight: 700;
+        color: v.$gray-500;
+        letter-spacing: 0.05em;
+        padding-top: 2px;
+      }
+
+      .grid-val {
+        font-size: 13px;
+        color: v.$gray-700;
+        line-height: 1.45;
+      }
+    }
+  }
+
+  .technical-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-top: 10px;
+    padding: 0;
+    background: none;
+    border: none;
+    color: v.$status-info;
+    font-size: 12px;
+    font-weight: 600;
+    cursor: pointer;
+
+    .material-icons {
+      font-size: 16px;
+    }
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+
+  .technical-detail {
+    margin: 8px 0 0;
+    padding: 10px 12px;
+    background: v.$gray-100;
+    border: 1px solid v.$gray-200;
+    border-radius: 4px;
+    font-family: 'Roboto Mono', 'Courier New', monospace;
+    font-size: 12px;
+    color: v.$gray-700;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-x: auto;
+  }
+
+  .issue-actions {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 14px;
+
+    // Cyan-outline primary action (design spec: border #00bcd4, bg #e8fafd, text #00838f).
+    .btn-fix {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 7px 14px;
+      background: #e8fafd;
+      border: 1px solid v.$active-color;
+      border-radius: 4px;
+      color: v.$status-info;
+      font-size: 13px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s ease;
+
+      .material-icons {
+        font-size: 16px;
+      }
+
+      &:hover {
+        background: color-mix(in srgb, #e8fafd 80%, v.$active-color 20%);
+      }
+
+      &:focus-visible {
+        outline: 2px solid v.$active-color;
+        outline-offset: 1px;
+      }
+    }
+
+    .btn-dismiss {
+      padding: 7px 12px;
+      background: transparent;
+      border: 1px solid v.$gray-300;
+      border-radius: 4px;
+      color: v.$gray-600;
+      font-size: 13px;
+      cursor: pointer;
+
+      &:hover {
+        background: v.$gray-100;
+      }
+    }
+  }
+}

--- a/src/app/preprocessing-wizard/shared/wizard-issue-card/wizard-issue-card.component.spec.ts
+++ b/src/app/preprocessing-wizard/shared/wizard-issue-card/wizard-issue-card.component.spec.ts
@@ -1,0 +1,107 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { WizardIssueCardComponent } from './wizard-issue-card.component';
+import { WizardIssue } from '../constants/wizard-error-classes';
+
+/**
+ * A3 — component test for the presentational issue card. Verifies that the
+ * everyday-language title, WHY and FIX are always visible, that the raw
+ * technical text is hidden until the user expands "Technical details", and
+ * that the fix/dismiss outputs emit.
+ */
+describe('WizardIssueCardComponent', () => {
+  let fixture: ComponentFixture<WizardIssueCardComponent>;
+  let component: WizardIssueCardComponent;
+
+  const blockingIssue: WizardIssue = {
+    code: 'K1',
+    severity: 'blocking',
+    title: 'A projection column still contains text values',
+    why: 'Text values ended up in the feature matrix.',
+    fix: 'Set an encoding for that column in Step 3.',
+    step: 2,
+    anchorId: 'wizard-anchor-columns',
+    raw: 'ValueError: could not convert string to float: "abc"',
+  };
+
+  function text(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [WizardIssueCardComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WizardIssueCardComponent);
+    component = fixture.componentInstance;
+    component.issue = { ...blockingIssue };
+    fixture.detectChanges();
+  });
+
+  it('renders the everyday title, WHY and FIX visibly', () => {
+    const content = text();
+    expect(content).toContain(blockingIssue.title);
+    expect(content).toContain(blockingIssue.why);
+    expect(content).toContain(blockingIssue.fix);
+  });
+
+  it('shows the class badge and a Blocking pill for a blocking issue', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.class-badge')?.textContent?.trim()).toBe('K1');
+    expect(el.querySelector('.severity-pill')?.textContent?.trim()).toBe('Blocking');
+  });
+
+  it('hides the raw technical text until "Technical details" is expanded', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    // Collapsed: the raw text is not in the DOM at all.
+    expect(el.querySelector('.technical-detail')).toBeNull();
+    expect(text()).not.toContain('could not convert string to float');
+
+    // Expand.
+    component.toggleTechnical();
+    fixture.detectChanges();
+
+    const pre = el.querySelector('.technical-detail');
+    expect(pre).not.toBeNull();
+    expect(pre!.textContent).toContain('could not convert string to float');
+  });
+
+  it('does not render the technical toggle when there is no raw detail', () => {
+    component.issue = { ...blockingIssue, raw: undefined };
+    fixture.detectChanges();
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.technical-toggle')).toBeNull();
+  });
+
+  it('emits fix with the issue when the "Fix in Schritt N" button is clicked', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    let emitted: WizardIssue | undefined;
+    component.fix.subscribe(i => (emitted = i));
+    (el.querySelector('.btn-fix') as HTMLButtonElement).click();
+    expect(emitted).toBe(component.issue);
+    // The button labels the responsible step (step index 2 → "Schritt 3").
+    expect((el.querySelector('.btn-fix') as HTMLElement).textContent).toContain('Schritt 3');
+  });
+
+  it('shows a Dismiss button only for dismissable issues and emits on click', () => {
+    let el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelector('.btn-dismiss')).toBeNull();
+
+    component.issue = { ...blockingIssue, dismissable: true };
+    fixture.detectChanges();
+    el = fixture.nativeElement as HTMLElement;
+
+    let dismissed = false;
+    component.dismiss.subscribe(() => (dismissed = true));
+    (el.querySelector('.btn-dismiss') as HTMLButtonElement).click();
+    expect(dismissed).toBe(true);
+  });
+
+  it('uses a custom severity label when provided', () => {
+    component.severityLabel = 'Possible issue';
+    fixture.detectChanges();
+    expect((fixture.nativeElement as HTMLElement).querySelector('.severity-pill')?.textContent?.trim()).toBe(
+      'Possible issue'
+    );
+  });
+});

--- a/src/app/preprocessing-wizard/shared/wizard-issue-card/wizard-issue-card.component.ts
+++ b/src/app/preprocessing-wizard/shared/wizard-issue-card/wizard-issue-card.component.ts
@@ -1,0 +1,43 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { WizardIssue, STEP_NAMES } from '../constants/wizard-error-classes';
+
+/**
+ * A3: presentational card for a single wizard issue. Shows severity, an
+ * everyday-language title, the WHY (cause) and FIX (action naming the step),
+ * collapsible technical details, and a "Fix in Schritt N" jump button that the
+ * host wires to the A6 step-jump logic. Optionally dismissable (partial issues).
+ */
+@Component({
+  selector: 'app-wizard-issue-card',
+  standalone: true,
+  imports: [],
+  templateUrl: './wizard-issue-card.component.html',
+  styleUrl: './wizard-issue-card.component.scss',
+})
+export class WizardIssueCardComponent {
+  @Input({ required: true }) issue!: WizardIssue;
+  /** Label shown on the severity pill: Blocking / Warning / Possible issue. */
+  @Input() severityLabel = '';
+  @Output() fix = new EventEmitter<WizardIssue>();
+  @Output() dismiss = new EventEmitter<WizardIssue>();
+
+  readonly STEP_NAMES = STEP_NAMES;
+  technicalOpen = false;
+
+  get stepNumber(): number {
+    return this.issue.step + 1;
+  }
+
+  get stepName(): string {
+    return STEP_NAMES[this.issue.step] ?? '';
+  }
+
+  get pillLabel(): string {
+    if (this.severityLabel) return this.severityLabel;
+    return this.issue.severity === 'blocking' ? 'Blocking' : 'Warning';
+  }
+
+  toggleTechnical(): void {
+    this.technicalOpen = !this.technicalOpen;
+  }
+}

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -96,7 +96,13 @@
         @if (selectedGlyphFeatures.length > 0 && selectedGlyphFeatures.length < MIN_GLYPH_FEATURES) {
           <div class="validation-warning">
             <span class="material-icons">warning</span>
-            <span>{{ MIN_GLYPH_FEATURES - selectedGlyphFeatures.length }} more needed</span>
+            <span>{{ MIN_GLYPH_FEATURES - selectedGlyphFeatures.length }} more needed (a glyph needs 3–12 features)</span>
+          </div>
+        }
+        @if (selectedGlyphFeatures.length > MAX_GLYPH_FEATURES) {
+          <div class="validation-warning">
+            <span class="material-icons">error_outline</span>
+            <span>Remove {{ selectedGlyphFeatures.length - MAX_GLYPH_FEATURES }} — a glyph takes at most {{ MAX_GLYPH_FEATURES }} features</span>
           </div>
         }
 
@@ -525,6 +531,12 @@
                         class="number-input"
                       />
                     </div>
+                    @if (neighborParamError(param)) {
+                      <div class="param-inline-error">
+                        <span class="material-icons">error_outline</span>
+                        <span>{{ neighborParamError(param) }}</span>
+                      </div>
+                    }
                   </div>
                 }
                 @if (method.key === 'enableTSNE' && shouldShowTSNEWarning()) {

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -714,6 +714,23 @@
         flex: 1 1 100%;
         min-width: 0;
 
+        // A3 / C-S4-05: field-near validation message (error class K4).
+        .param-inline-error {
+          display: flex;
+          align-items: flex-start;
+          gap: 5px;
+          margin-top: 5px;
+          font-size: 11px;
+          line-height: 1.4;
+          color: v.$status-error-dark;
+
+          .material-icons {
+            font-size: 14px;
+            color: #d64541;
+            flex-shrink: 0;
+          }
+        }
+
         label {
           display: flex;
           align-items: center;

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
@@ -736,6 +736,30 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
     this.updateProjectionConfig();
   }
 
+  /**
+   * A3 / C-S4-05: field-near validation for neighbour parameters (error class K4).
+   * A neighbour count at or above the row count makes IsoMap / LLE / LTSA / UMAP
+   * fail during processing; we flag it right at the parameter instead of only
+   * surfacing a cryptic error later in Step 5. Returns null when valid.
+   * (0 means "auto" for IsoMap/LLE/LTSA and is always valid.)
+   */
+  neighborParamError(param: ProjectionParam): string | null {
+    const neighborKeys: (keyof ProjectionConfig)[] = [
+      'isomapNeighbors',
+      'lleNeighbors',
+      'ltsaNeighbors',
+      'umapNeighbors',
+    ];
+    if (!neighborKeys.includes(param.configKey)) return null;
+
+    const value = this.projectionConfig[param.configKey] as number;
+    const rows = this.getDatasetRowCount();
+    if (value > 0 && rows > 0 && value >= rows) {
+      return `Only ${rows} rows available — set neighbours below ${rows}, or this method will fail during processing.`;
+    }
+    return null;
+  }
+
   onParamChange(configKey: keyof ProjectionConfig, value: number, min: number, max: number): void {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (this.projectionConfig as any)[configKey] = Math.max(min, Math.min(max, value));

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.html
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.html
@@ -1,11 +1,19 @@
 <div class="step5-review-processing">
   <div class="step-content">
+    <!-- Persistence signifier: reassures that data + settings survive every state -->
+    @if (showProcessing) {
+      <div class="persistence-pill" title="Your uploaded data and all settings are kept">
+        <span class="material-icons">save</span>
+        <span>Your work is saved</span>
+      </div>
+    }
+
     <!-- ========================================================================== -->
-    <!-- REVIEW SECTION -->
+    <!-- REVIEW SECTION (pre-flight) -->
     <!-- ========================================================================== -->
     @if (!showProcessing) {
       <div class="review-section">
-        <!-- Configuration Summary -->
+        <!-- Configuration Summary (metric tiles + A6 edit jumps) -->
         <div class="summary-cards">
           <div class="summary-card">
             <div class="card-icon"><span class="material-icons">view_column</span></div>
@@ -88,6 +96,27 @@
           </div>
         </div>
 
+        <!-- Pre-flight banner + possible issues -->
+        @if (preflightIssues.length > 0) {
+          <div class="preflight-banner">
+            <span class="material-icons">info</span>
+            <div>
+              <strong>Heads up</strong> — {{ preflightIssues.length }}
+              {{ preflightIssues.length === 1 ? 'thing' : 'things' }} could cause processing to fail. You can start
+              anyway, or fix them first.
+            </div>
+          </div>
+          <div class="issue-list">
+            @for (issue of preflightIssues; track issue.code + issue.title) {
+              <app-wizard-issue-card
+                [issue]="issue"
+                severityLabel="Possible issue"
+                (fix)="fixInStep($event)"
+              ></app-wizard-issue-card>
+            }
+          </div>
+        }
+
         <!-- Column Details Table -->
         <div class="columns-table">
           <table>
@@ -149,120 +178,154 @@
           <div>
             <strong>Processing Info:</strong> Processing time depends on your dataset size and enabled projection
             methods. FastMap loads immediately, allowing you to explore your data right away. Additional projections
-            compute in the background.
+            compute in the background. If anything fails, it appears here with a fix — never a blank screen.
           </div>
         </div>
       </div>
     }
 
     <!-- ========================================================================== -->
-    <!-- PROCESSING SECTION -->
+    <!-- PROCESSING / RESULT / ERROR SECTION -->
     <!-- ========================================================================== -->
     @if (showProcessing) {
+      <!-- PROCESSING -->
       @if (isProcessing) {
-        <!-- Processing View -->
-        <div class="processing-view">
-          <div class="processing-card">
-            <div class="processing-icon">
-              <span class="material-icons spinning">sync</span>
+        <div class="status-panel">
+          <div class="status-hero processing">
+            <span class="material-icons spinning">sync</span>
+            <div>
+              <h3>{{ processingStep || 'FastMap is computing your primary layout…' }}</h3>
+              <p>
+                FastMap loads first so you can explore right away. Other projections keep computing in the background —
+                if a problem comes up, it shows here, not on a blank page.
+              </p>
             </div>
+          </div>
 
-            <h3>Processing Your Data</h3>
-            <p class="processing-message">{{ processingStep || 'Applying your preprocessing configuration...' }}</p>
+          <div class="progress-bar">
+            <div class="progress-fill" [style.width.%]="processingProgress"></div>
+          </div>
+          <div class="progress-text">{{ processingProgress }}%</div>
 
-            <div class="progress-bar">
-              <div class="progress-fill" [style.width.%]="processingProgress"></div>
+          <ng-container *ngTemplateOutlet="methodBar"></ng-container>
+        </div>
+      }
+
+      <!-- BLOCKING ERROR -->
+      @if (isErrorScreen && blockingIssue) {
+        <div class="status-panel">
+          <div class="status-hero error">
+            <span class="material-icons">error_outline</span>
+            <div>
+              <h3>We couldn't finish your visualization — but this is fixable.</h3>
+              <p>Deine hochgeladenen Daten und alle Einstellungen sind noch da — nichts ging verloren.</p>
             </div>
+          </div>
 
-            <div class="progress-text">{{ processingProgress }}%</div>
+          <ng-container *ngTemplateOutlet="methodBar"></ng-container>
+
+          <div class="issue-list">
+            <app-wizard-issue-card
+              [issue]="blockingIssue"
+              severityLabel="Blocking"
+              (fix)="fixInStep($event)"
+            ></app-wizard-issue-card>
           </div>
         </div>
       }
 
+      <!-- SUCCESS / PARTIAL -->
       @if (processingComplete && !isProcessing) {
-        <!-- Success View -->
-        <div class="success-view">
-          <div class="success-card">
-            <div class="success-icon">
-              <span class="material-icons">check_circle</span>
+        <div class="status-panel">
+          <div class="success-banner">
+            <span class="material-icons">check_circle</span>
+            <div>
+              <h3>Your visualization is ready</h3>
+              <p>FastMap is loaded — open Glyphspace to start exploring. Additional projections finish in the background.</p>
             </div>
+          </div>
 
-            <h3>Processing Complete!</h3>
-            <p class="success-message">Your dataset has been successfully processed and is ready for visualization.</p>
-
+          @if (isPartialResult) {
+            <div class="partial-notice">
+              <span class="material-icons">warning</span>
+              <div>
+                {{ partialIssues.length }} of {{ enabledMethods.length }} projections could not be computed. Your
+                visualization still works with the ones that succeeded.
+              </div>
+            </div>
+            <div class="issue-list">
+              @for (issue of partialIssues; track issue.title) {
+                <app-wizard-issue-card
+                  [issue]="issue"
+                  severityLabel="Warning"
+                  (fix)="fixInStep($event)"
+                  (dismiss)="dismissIssue($event)"
+                ></app-wizard-issue-card>
+              }
+            </div>
+          } @else {
             <div class="success-stats">
-              <div class="stat-item">
-                <span class="material-icons">check</span>
-                <span>{{ enabledColumns }} columns processed</span>
-              </div>
-              <div class="stat-item">
-                <span class="material-icons">check</span>
-                <span>FastMap projection ready</span>
-              </div>
-              <div class="stat-item">
-                <span class="material-icons">check</span>
-                <span>Data cleaning applied</span>
-              </div>
+              <div class="stat-item"><span class="material-icons">check</span><span>{{ enabledColumns }} columns processed</span></div>
+              <div class="stat-item"><span class="material-icons">check</span><span>FastMap projection ready</span></div>
+              <div class="stat-item"><span class="material-icons">check</span><span>Data cleaning applied</span></div>
             </div>
+          }
 
-            <!-- Background Projection Status -->
-            @if (getBackgroundProjectionsArray().length > 0) {
-              <div class="background-status-section">
-                <h4>
-                  <span class="material-icons">schedule</span>
-                  Background Projections
-                </h4>
-                <div class="projection-status-list">
-                  @for (proj of getBackgroundProjectionsArray(); track proj.method) {
-                    <div class="projection-status-item" [class]="'status-' + proj.status">
-                      <div class="status-header">
-                        <span class="method-name">{{ proj.method.toUpperCase() }}</span>
-                        @if (proj.status === 'running') {
-                          <span class="status-badge status-running">
-                            <span class="material-icons spinning">sync</span>
-                            Running
-                          </span>
-                        }
-                        @if (proj.status === 'complete') {
-                          <span class="status-badge status-complete">
-                            <span class="material-icons">check_circle</span>
-                            Complete
-                          </span>
-                        }
-                        @if (proj.status === 'error') {
-                          <span class="status-badge status-error">
-                            <span class="material-icons">error</span>
-                            Error
-                          </span>
-                        }
-                      </div>
+          <ng-container *ngTemplateOutlet="methodBar"></ng-container>
+
+          <!-- Detailed background projection progress -->
+          @if (getBackgroundProjectionsArray().length > 0) {
+            <div class="background-status-section">
+              <h4>
+                <span class="material-icons">schedule</span>
+                Background Projections
+              </h4>
+              <div class="projection-status-list">
+                @for (proj of getBackgroundProjectionsArray(); track proj.method) {
+                  <div class="projection-status-item" [class]="'status-' + proj.status">
+                    <div class="status-header">
+                      <span class="method-name">{{ proj.method.toUpperCase() }}</span>
                       @if (proj.status === 'running') {
-                        <div class="progress-bar-small">
-                          <div class="progress-fill-small" [style.width.%]="proj.progress"></div>
-                        </div>
-                        <p class="status-message">{{ proj.message }}</p>
+                        <span class="status-badge status-running"><span class="material-icons spinning">sync</span>Running</span>
                       }
                       @if (proj.status === 'complete') {
-                        <p class="status-message">Available in Glyphspace dropdown</p>
+                        <span class="status-badge status-complete"><span class="material-icons">check_circle</span>Complete</span>
+                      }
+                      @if (proj.status === 'error') {
+                        <span class="status-badge status-error"><span class="material-icons">error</span>Failed</span>
                       }
                     </div>
-                  }
-                </div>
+                    @if (proj.status === 'running') {
+                      <div class="progress-bar-small"><div class="progress-fill-small" [style.width.%]="proj.progress"></div></div>
+                      <p class="status-message">{{ proj.message }}</p>
+                    }
+                    @if (proj.status === 'complete') {
+                      <p class="status-message">Available in Glyphspace dropdown</p>
+                    }
+                  </div>
+                }
               </div>
-            }
-          </div>
-        </div>
-      }
-
-      @if (error) {
-        <!-- Error Message -->
-        <div class="error-message">
-          <span class="material-icons">error</span>
-          <div class="message-content"><strong>Error:</strong> {{ error }}</div>
+            </div>
+          }
         </div>
       }
     }
   </div>
+
+  <!-- Method status bar template (reused across processing / error / result) -->
+  <ng-template #methodBar>
+    <div class="method-bar">
+      @for (m of methodStatuses; track m.name) {
+        <div class="method-chip" [class]="'chip-' + m.status">
+          <div class="chip-top">
+            <span class="chip-name">{{ m.name }}</span>
+            <span class="chip-role">{{ m.role }}</span>
+          </div>
+          <span class="chip-status">{{ m.statusLabel }}</span>
+        </div>
+      }
+    </div>
+  </ng-template>
 
   <!-- Action Buttons -->
   @if (!showProcessing) {
@@ -271,11 +334,25 @@
         <span class="material-icons">arrow_back</span>
         <span>Back</span>
       </button>
-
       <div class="buttons-right">
         <button class="btn-primary" (click)="startProcessing()">
           <span class="material-icons">play_arrow</span>
           <span>Start Processing</span>
+        </button>
+      </div>
+    </div>
+  }
+
+  @if (isErrorScreen) {
+    <div class="action-buttons">
+      <button class="btn-secondary" (click)="goBack()">
+        <span class="material-icons">arrow_back</span>
+        <span>Back to settings</span>
+      </button>
+      <div class="buttons-right">
+        <button class="btn-primary" (click)="retryProcessing()">
+          <span class="material-icons">refresh</span>
+          <span>Try again</span>
         </button>
       </div>
     </div>
@@ -287,7 +364,6 @@
         <span class="material-icons">refresh</span>
         <span>Process Another Dataset</span>
       </button>
-
       <div class="buttons-right">
         <button class="btn-primary" (click)="goToDashboard()">
           <span class="material-icons">dashboard</span>

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.html
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.html
@@ -365,6 +365,14 @@
         <span>Process Another Dataset</span>
       </button>
       <div class="buttons-right">
+        <button
+          class="btn-secondary"
+          title="Run the projections again with the current settings"
+          (click)="retryProcessing()"
+        >
+          <span class="material-icons">replay</span>
+          <span>Reprocess</span>
+        </button>
         <button class="btn-primary" (click)="goToDashboard()">
           <span class="material-icons">dashboard</span>
           <span>Open in Glyphspace</span>

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.scss
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.scss
@@ -313,6 +313,327 @@
     }
   }
 
+  // A3: persistence signifier pill
+  .persistence-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    align-self: flex-start;
+    margin-bottom: 14px;
+    padding: 4px 10px;
+    background: rgba(v.$active-color, 0.1);
+    border: 1px solid rgba(v.$active-color, 0.4);
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+    color: v.$status-info;
+
+    .material-icons {
+      font-size: 15px;
+    }
+  }
+
+  // A3: pre-flight banner (amber)
+  .preflight-banner {
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    padding: 12px 14px;
+    margin-bottom: 12px;
+    background: #fffdf9;
+    border: 1px solid #f2dcb6;
+    border-radius: 6px;
+    font-size: 13px;
+    color: v.$gray-700;
+    line-height: 1.45;
+
+    .material-icons {
+      color: #d08a1e;
+      font-size: 20px;
+      flex-shrink: 0;
+    }
+  }
+
+  .issue-list {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  // A3: persistent status/error/result panel
+  .status-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    padding: 20px;
+    background: white;
+    border: 1px solid v.$gray-300;
+    border-radius: 8px;
+
+    .status-hero {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      padding: 16px;
+      border-radius: 6px;
+
+      .material-icons {
+        font-size: 40px;
+        flex-shrink: 0;
+
+        &.spinning {
+          animation: spin 1s linear infinite;
+        }
+      }
+
+      h3 {
+        font-size: 17px;
+        font-weight: 700;
+        margin: 0 0 4px;
+        color: v.$gray-800;
+      }
+
+      p {
+        font-size: 13px;
+        color: v.$gray-600;
+        margin: 0;
+        line-height: 1.45;
+      }
+
+      &.processing {
+        background: rgba(v.$active-color, 0.08);
+        .material-icons {
+          color: v.$active-color;
+        }
+      }
+
+      &.error {
+        background: #fffafa;
+        border: 1px solid #f0d3cf;
+        .material-icons {
+          color: #d64541;
+        }
+      }
+    }
+
+    .success-banner {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      padding: 16px;
+      background: #f1faf2;
+      border: 1px solid #c8ead0;
+      border-radius: 6px;
+
+      .material-icons {
+        font-size: 40px;
+        color: #2a9d4a;
+        flex-shrink: 0;
+      }
+
+      h3 {
+        font-size: 17px;
+        font-weight: 700;
+        margin: 0 0 4px;
+        color: v.$gray-800;
+      }
+
+      p {
+        font-size: 13px;
+        color: v.$gray-600;
+        margin: 0;
+        line-height: 1.45;
+      }
+    }
+
+    .partial-notice {
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      padding: 12px 14px;
+      background: #fffdf9;
+      border: 1px solid #f2dcb6;
+      border-radius: 6px;
+      font-size: 13px;
+      color: v.$gray-700;
+      line-height: 1.45;
+
+      .material-icons {
+        color: #d08a1e;
+        font-size: 20px;
+        flex-shrink: 0;
+      }
+    }
+
+    .progress-bar {
+      @include w.progress-bar;
+      width: 100%;
+      height: 8px;
+    }
+
+    .progress-fill {
+      @include w.progress-fill;
+    }
+
+    .progress-text {
+      font-size: 16px;
+      font-weight: 700;
+      color: v.$active-color;
+      text-align: center;
+    }
+
+    .success-stats {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+
+      .stat-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        font-size: 14px;
+        color: v.$gray-700;
+
+        .material-icons {
+          font-size: 18px;
+          color: #2a9d4a;
+        }
+      }
+    }
+
+    // Method status bar
+    .method-bar {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+
+      .method-chip {
+        flex: 1 1 140px;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        padding: 10px 12px;
+        border: 1px solid v.$gray-200;
+        border-radius: 6px;
+        background: v.$gray-100;
+
+        .chip-top {
+          display: flex;
+          align-items: baseline;
+          gap: 6px;
+
+          .chip-name {
+            font-size: 13px;
+            font-weight: 700;
+            color: v.$gray-800;
+          }
+
+          .chip-role {
+            font-size: 10px;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+            color: v.$gray-500;
+          }
+        }
+
+        .chip-status {
+          font-size: 12px;
+          font-weight: 600;
+          color: v.$gray-600;
+        }
+
+        &.chip-ready {
+          background: #f1faf2;
+          border-color: #c8ead0;
+          .chip-status {
+            color: #2a9d4a;
+          }
+        }
+
+        &.chip-computing {
+          background: rgba(v.$active-color, 0.08);
+          border-color: rgba(v.$active-color, 0.35);
+          .chip-status {
+            color: v.$status-info;
+          }
+        }
+
+        &.chip-failed {
+          background: #fffafa;
+          border-color: #f0d3cf;
+          .chip-status {
+            color: #d64541;
+          }
+        }
+      }
+    }
+
+    .background-status-section {
+      padding-top: 8px;
+      border-top: 1px solid v.$gray-200;
+
+      h4 {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 14px;
+        font-weight: 600;
+        color: v.$gray-700;
+        margin: 0 0 12px;
+
+        .material-icons {
+          font-size: 18px;
+        }
+      }
+
+      .projection-status-list {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+
+        .projection-status-item {
+          padding: 10px;
+          background: v.$gray-100;
+          border-radius: 4px;
+
+          .status-header {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            margin-bottom: 6px;
+
+            .method-name {
+              font-size: 13px;
+              font-weight: 600;
+              color: v.$gray-800;
+            }
+
+            .status-badge {
+              @include w.status-badge;
+            }
+          }
+
+          .progress-bar-small {
+            @include w.progress-bar;
+            height: 4px;
+            margin-bottom: 4px;
+
+            .progress-fill-small {
+              @include w.progress-fill;
+            }
+          }
+
+          .status-message {
+            font-size: 12px;
+            color: v.$gray-600;
+            margin: 0;
+          }
+        }
+      }
+    }
+  }
+
   .error-message {
     @include w.message-error;
   }

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.ts
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.ts
@@ -197,6 +197,24 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
     });
   }
 
+  /** Minimum time the loading hero stays on screen so a fast run -- or a fast
+   *  failure -- is actually perceivable instead of a one-frame flash. */
+  private readonly MIN_LOADING_MS = 600;
+
+  /** Resolve after the browser has had a chance to paint, so a state change
+   *  made right before heavy work is rendered first. */
+  private paintYield(): Promise<void> {
+    return new Promise<void>(resolve => requestAnimationFrame(() => setTimeout(resolve, 0)));
+  }
+
+  /** Hold until the loading hero has been visible for at least MIN_LOADING_MS. */
+  private async ensureMinVisible(startedAt: number): Promise<void> {
+    const remaining = this.MIN_LOADING_MS - (performance.now() - startedAt);
+    if (remaining > 0) {
+      await new Promise<void>(resolve => setTimeout(resolve, remaining));
+    }
+  }
+
   async startProcessing(): Promise<void> {
     this.resetProcessingState();
     this.showProcessing = true;
@@ -210,6 +228,11 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
         this.cdr.detectChanges();
       },
     });
+
+    // Keep the loading hero visible for a perceptible minimum, measured from
+    // here, and let the browser paint it before the heavy work begins.
+    const startedAt = performance.now();
+    await this.paintYield();
 
     try {
       await this.preprocessingService.processData();
@@ -228,6 +251,7 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
 
       await this.preprocessingService.addProjectionPositions('fastmap', fastmapResult.positions);
 
+      await this.ensureMinVisible(startedAt);
       this.ngZone.run(() => {
         this.processingProgress = 100;
         this.processingStep = `Dataset loaded with FastMap (${fastmapResult.computeTime}ms)`;
@@ -239,6 +263,7 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
       this.startBackgroundProjections(features, ids);
     } catch (error: unknown) {
       console.error('Processing failed:', error);
+      await this.ensureMinVisible(startedAt);
       this.ngZone.run(() => {
         const raw = error instanceof Error ? error.message : String(error);
         this.error = raw;

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.ts
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, OnDestroy, ChangeDetectorRef, NgZone, Output, EventEmitter } from '@angular/core';
+import { NgTemplateOutlet } from '@angular/common';
 import { Subscription } from 'rxjs';
 import { PreprocessingService } from '../../services/preprocessing.service';
 import { DataLoaderService } from '../../../services/data-loader.service';
@@ -8,11 +9,27 @@ import { ColumnConfig, ProjectionConfig } from '../../models/column-config';
 import { DataType, getEncodingLabel as encLabelFn, getScalingLabel as scaleLabelFn } from '../../models/data-type.enum';
 import { STEP_INFO } from '../../shared/constants/step-info';
 import { DataTypeBadgeComponent } from '../../shared/data-type-badge/data-type-badge.component';
+import { WizardIssueCardComponent } from '../../shared/wizard-issue-card/wizard-issue-card.component';
+import {
+  WizardIssue,
+  STEP_NAMES,
+  classifyProcessingError,
+  classifyBackgroundFailure,
+  detectPreflightIssues,
+} from '../../shared/constants/wizard-error-classes';
+
+/** One entry in the method status bar (FastMap / PCA / UMAP / …). */
+interface MethodStatus {
+  name: string;
+  role: string;
+  status: 'ready' | 'computing' | 'queued' | 'failed';
+  statusLabel: string;
+}
 
 @Component({
   selector: 'app-step5-review-processing',
   standalone: true,
-  imports: [DataTypeBadgeComponent],
+  imports: [NgTemplateOutlet, DataTypeBadgeComponent, WizardIssueCardComponent],
   templateUrl: './step5-review-processing.component.html',
   styleUrl: './step5-review-processing.component.scss',
 })
@@ -40,7 +57,16 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
   showProcessing = false;
 
   // Background projection status
-  backgroundProjections = new Map<string, { status: string; progress: number; message: string }>();
+  backgroundProjections = new Map<string, { status: string; progress: number; message: string; error?: string }>();
+
+  // A3: structured, persistent issues.
+  preflightIssues: WizardIssue[] = []; // shown on the review screen before processing
+  blockingIssue: WizardIssue | null = null; // primary (hard) failure — replaces the old bare "error" string
+  partialIssues: WizardIssue[] = []; // degraded: some background projections failed (dismissable)
+  private dismissedMethods = new Set<string>();
+  private expandedTechnical = new Set<string>();
+
+  readonly STEP_NAMES = STEP_NAMES;
 
   // Capture dataset info for background projections (survives wizard reset)
   private backgroundDatasetName = '';
@@ -78,6 +104,35 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
 
     // Prepare review data
     this.prepareReviewData();
+
+    // A3: pre-flight — surface likely failures from signals already in the state.
+    this.preflightIssues = detectPreflightIssues(state);
+
+    // A3 / A11 (P-S5-02, P-S5-03): restore the persistent result/status on re-entry.
+    // The service is a root singleton, so background statuses and the processed
+    // dataset survive closing the wizard. Re-subscribe to keep the method bar and
+    // partial-failure detection alive after reopening.
+    this.backgroundStatusSubscription = this.projectionService.backgroundStatusObservable.subscribe(statusMap => {
+      this.ngZone.run(() => {
+        this.syncBackgroundStatus(statusMap);
+        this.cdr.detectChanges();
+      });
+    });
+
+    if (state.error) {
+      // A previous run failed and the error survived in the singleton state.
+      // Show it as a persistent, classified error screen instead of a stale banner.
+      this.blockingIssue = classifyProcessingError(state.error);
+      this.showProcessing = true;
+      this.isProcessing = false;
+      this.processingComplete = false;
+    } else if (state.processedDataset) {
+      // Processing already finished in an earlier session of this wizard instance:
+      // restore the success/result screen rather than the "Start Processing" view.
+      this.showProcessing = true;
+      this.processingComplete = true;
+      this.isProcessing = false;
+    }
   }
 
   ngOnDestroy(): void {
@@ -126,6 +181,12 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
     this.processingStep = '';
     this.error = null;
     this.showProcessing = false;
+    this.blockingIssue = null;
+    this.partialIssues = [];
+    this.dismissedMethods.clear();
+    this.expandedTechnical.clear();
+    // Clear any stale error left in the singleton state (P-S5-03).
+    this.preprocessingService.clearError();
   }
 
   private updateProcessingUI(step: string, progress: number): void {
@@ -179,8 +240,12 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
     } catch (error: unknown) {
       console.error('Processing failed:', error);
       this.ngZone.run(() => {
-        this.error = error instanceof Error ? error.message : 'Processing failed';
+        const raw = error instanceof Error ? error.message : String(error);
+        this.error = raw;
+        // A3: classify into a persistent, actionable issue (cause + fix + target step).
+        this.blockingIssue = classifyProcessingError(raw);
         this.isProcessing = false;
+        this.processingComplete = false;
         this.cdr.detectChanges();
       });
     } finally {
@@ -199,19 +264,8 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
     this.backgroundDatasetName = state.datasetName;
     this.backgroundTimestamp = state.timestamp;
 
-    this.backgroundStatusSubscription = this.projectionService.backgroundStatusObservable.subscribe(statusMap => {
-      this.ngZone.run(() => {
-        this.backgroundProjections.clear();
-        statusMap.forEach((status, method) => {
-          this.backgroundProjections.set(method, {
-            status: status.status,
-            progress: status.progress,
-            message: status.message,
-          });
-        });
-        this.cdr.detectChanges();
-      });
-    });
+    // Note: the background-status subscription is created once in ngOnInit so it
+    // also restores the method bar after the wizard is reopened.
 
     // Data-driven projection registry: each entry maps a config flag to its runner
     const projections: { enabled: boolean; name: string; run: () => Promise<ProjectionResult> }[] = [
@@ -385,5 +439,124 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
       result.push({ method: key, ...value });
     });
     return result;
+  }
+
+  // ============================================================================
+  // A3: persistent status/error screen
+  // ============================================================================
+
+  /** Copy the latest background status into the local map and rebuild the
+   *  degraded/partial issue list from any failed background projections. */
+  private syncBackgroundStatus(statusMap: Map<string, { status: string; progress: number; message: string; error?: string }>): void {
+    this.backgroundProjections.clear();
+    statusMap.forEach((status, method) => {
+      this.backgroundProjections.set(method, {
+        status: status.status,
+        progress: status.progress,
+        message: status.message,
+        error: status.error,
+      });
+    });
+
+    this.partialIssues = [];
+    this.backgroundProjections.forEach((value, method) => {
+      if (value.status === 'error' && !this.dismissedMethods.has(method)) {
+        this.partialIssues.push(classifyBackgroundFailure(method, value.error || value.message));
+      }
+    });
+  }
+
+  /** True once processing succeeded but at least one background projection failed. */
+  get isPartialResult(): boolean {
+    return this.processingComplete && !this.isProcessing && this.partialIssues.length > 0;
+  }
+
+  /** True when the primary run failed (hard, blocking error screen). */
+  get isErrorScreen(): boolean {
+    return !!this.blockingIssue && !this.isProcessing;
+  }
+
+  /** Method status bar (FastMap primary + enabled background methods). */
+  get methodStatuses(): MethodStatus[] {
+    const roleFor = (name: string): string => {
+      if (name.startsWith('FastMap')) return 'Primary';
+      if (name === 'PCA') return 'Instant';
+      if (name === 't-SNE' || name === 'Sammon') return 'Slow';
+      return 'Background';
+    };
+
+    return this.enabledMethods.map(label => {
+      const isPrimary = label.startsWith('FastMap');
+      // Background status keys are lowercase alphanumeric ids (e.g. "tsne").
+      const key = label.replace(' (Primary)', '').toLowerCase().replace(/[^a-z0-9]/g, '');
+      let status: MethodStatus['status'];
+
+      if (isPrimary) {
+        if (this.blockingIssue) status = 'failed';
+        else if (this.processingComplete) status = 'ready';
+        else if (this.isProcessing) status = 'computing';
+        else status = 'queued';
+      } else {
+        const bg = this.backgroundProjections.get(key);
+        if (bg) {
+          if (bg.status === 'complete') status = 'ready';
+          else if (bg.status === 'running') status = 'computing';
+          else if (bg.status === 'error') status = 'failed';
+          else status = 'queued';
+        } else {
+          // Not tracked via the worker status stream (e.g. PCA runs instantly):
+          // assume ready once the primary run has finished, otherwise queued.
+          status = this.processingComplete ? 'ready' : 'queued';
+        }
+      }
+
+      const labels: Record<MethodStatus['status'], string> = {
+        ready: 'Ready',
+        computing: 'Computing…',
+        queued: 'Queued',
+        failed: 'Failed',
+      };
+
+      return { name: label.replace(' (Primary)', ''), role: roleFor(label), status, statusLabel: labels[status] };
+    });
+  }
+
+  /** "Fix in Schritt N" — reuse the A6 jump/scroll logic and confirm with a toast. */
+  fixInStep(issue: WizardIssue): void {
+    const stepNumber = issue.step + 1;
+    const stepName = STEP_NAMES[issue.step] ?? '';
+    if (issue.anchorId) {
+      this.preprocessingService.goToStepWithScroll(issue.step, issue.anchorId);
+    } else {
+      this.preprocessingService.goToStep(issue.step);
+    }
+    this.toastService.info(`Opening Step ${stepNumber} · ${stepName}`, 2500);
+  }
+
+  /** Dismiss a partial (optional) issue so the degraded notice can be cleared. */
+  dismissIssue(issue: WizardIssue): void {
+    const method = this.getMethodForPartialIssue(issue);
+    if (method) this.dismissedMethods.add(method);
+    this.partialIssues = this.partialIssues.filter(i => i !== issue);
+  }
+
+  private getMethodForPartialIssue(issue: WizardIssue): string | null {
+    // Titles are "<METHOD> could not be computed".
+    const match = issue.title.match(/^(\S+) could not be computed/);
+    return match ? match[1].toLowerCase() : null;
+  }
+
+  toggleTechnical(id: string): void {
+    if (this.expandedTechnical.has(id)) this.expandedTechnical.delete(id);
+    else this.expandedTechnical.add(id);
+  }
+
+  isTechnicalExpanded(id: string): boolean {
+    return this.expandedTechnical.has(id);
+  }
+
+  /** Retry after a blocking error, keeping all uploaded data and settings. */
+  retryProcessing(): void {
+    this.startProcessing();
   }
 }

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.ts
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.ts
@@ -364,12 +364,14 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
         this.toastService.success(`${name} projection ready! (${(result.computeTime / 1000).toFixed(1)}s)`, 4000);
       });
     } catch (error: unknown) {
+      const raw = error instanceof Error ? error.message : String(error);
       console.error(`${name} projection failed:`, error);
       this.ngZone.run(() => {
-        this.toastService.error(
-          `${name} projection failed: ${error instanceof Error ? error.message : String(error)}`,
-          6000
-        );
+        // A3 review fix: never surface the raw technical message in the toast.
+        // Use the classified, everyday-language title; the full WHY/FIX and the
+        // raw detail live in the partial-issue card's collapsible section.
+        const issue = classifyBackgroundFailure(name, raw);
+        this.toastService.error(issue.title, 6000);
       });
     }
   }
@@ -555,8 +557,26 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
     return this.expandedTechnical.has(id);
   }
 
-  /** Retry after a blocking error, keeping all uploaded data and settings. */
+  /**
+   * Retry / reprocess, keeping all uploaded data and settings. Reachable from
+   * both the blocking-error screen and the success screen.
+   *
+   * A3 review fix: the earlier version only called startProcessing(), so a fast
+   * run looked like a brief flash with no confirmation that anything happened.
+   * We now announce the retry with a toast and force the processing hero to show
+   * (isProcessing/showProcessing) before the async work begins, so the user
+   * clearly sees the spinner + progress + method status while it re-runs.
+   */
   retryProcessing(): void {
+    this.toastService.info('Verarbeitung wird erneut gestartet…', 3000);
+    // Make the processing state visible immediately, even before startProcessing's
+    // own reset runs, so the transition is never just a flicker.
+    this.showProcessing = true;
+    this.isProcessing = true;
+    this.processingComplete = false;
+    this.blockingIssue = null;
+    this.processingStep = 'Restarting processing…';
+    this.cdr.detectChanges();
     this.startProcessing();
   }
 }

--- a/src/app/services/data-processor.ts
+++ b/src/app/services/data-processor.ts
@@ -216,7 +216,10 @@ export class DataProcessorService {
         if (msg.type === 'error') {
           clearTimeout(timer);
           sub.unsubscribe();
-          reject(msg.message);
+          // Wrap the worker message in an Error so the real cause survives the
+          // `instanceof Error` check downstream (was rejected as a bare string,
+          // which forced the generic "Processing failed" fallback).
+          reject(new Error(typeof msg.message === 'string' ? msg.message : 'Worker reported an error'));
         } else if (msg.type === type && matchFn(msg as T)) {
           clearTimeout(timer);
           sub.unsubscribe();

--- a/src/app/workers/pyodide.worker.ts
+++ b/src/app/workers/pyodide.worker.ts
@@ -260,13 +260,12 @@ preprocessing_processor_config.process_with_config(
 
           postMessage({ type: 'processed', dataset } as WorkerReply);
 
-          // Cleanup: files are no longer needed after processing
+          // Cleanup: only remove the transient result file. The input CSV must
+          // stay in the Pyodide FS -- it is written once at upload (profileData)
+          // and reused for every (re)processing run, and the app does not retain
+          // the raw bytes to re-write it. Deleting it here caused a
+          // FileNotFoundError ('<name>' not found) on the second run / reprocess.
           try {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Pyodide FS API has incomplete type definitions
-            if ((pyodide.FS as any).analyzePath(fileName).exists) {
-              // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Pyodide FS API has incomplete type definitions
-              (pyodide.FS as any).unlink(fileName);
-            }
             // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Pyodide FS API has incomplete type definitions
             if ((pyodide.FS as any).analyzePath(outputFileName).exists) {
               // eslint-disable-next-line @typescript-eslint/no-explicit-any -- Pyodide FS API has incomplete type definitions

--- a/src/assets/preprocessing_processor_config.py
+++ b/src/assets/preprocessing_processor_config.py
@@ -154,6 +154,36 @@ def apply_feature_engineering(df, config):
     feature_cols = [col for col in df.columns if col != 'ID']
     enabled_cols = [col for col in feature_cols if column_configs.get(col, {}).get('enabled', True)]
 
+    # Guard against the one-hot explosion (wizard error class K7): a text column
+    # that is near-unique (an ID, title, name or free-text field) would expand
+    # into one feature column per distinct value and exhaust the browser's
+    # (Pyodide) memory. Detect these up front and fail fast with a clear,
+    # actionable message naming every offending column, instead of an opaque
+    # numpy MemoryError deep inside pandas.concat.
+    MAX_ONEHOT_UNIQUE = 500
+    onehot_offenders = []
+    for col in enabled_cols:
+        col_config = column_configs.get(col, {})
+        encoding = col_config.get('encoding', 'none')
+        data_type = col_config.get('dataType', 'unknown')
+        col_data = df[col]
+        is_onehot = encoding == 'onehot' or (
+            encoding == 'none'
+            and data_type not in ('date', 'boolean')
+            and not pd.api.types.is_numeric_dtype(col_data)
+        )
+        if is_onehot:
+            n_unique = col_data.fillna('missing').astype(str).nunique()
+            if n_unique > MAX_ONEHOT_UNIQUE:
+                onehot_offenders.append((col, n_unique))
+    if onehot_offenders:
+        listed = ", ".join(f"'{name}' ({n} distinct values)" for name, n in onehot_offenders)
+        raise Exception(
+            f"These columns have too many distinct values to one-hot encode: {listed}. "
+            f"Each would expand into that many feature columns, which exceeds the in-browser memory. "
+            f"Deselect them in the column step, or switch their encoding to label."
+        )
+
     # PHASE 1: Encoding - collect all encoded columns in a list
     encoded_dfs = []
     feature_names = []


### PR DESCRIPTION
## Ticket A3 – Fehlermeldungen inline, verständlich, lösungsorientiert

Umsetzung nach Design-Template „Wizard Error Handling", gegengecheckt mit `01_Results/fehlerklassen-ableitbarkeit.html` und `fehlerbehandlung-wizard-analyse.html`. Enthält auch die Persistent-Result-Fixes aus A11 (P-S5-02/03).

### Was gemacht
- Ursachen-Fix: Worker-Fehler werden als echte `Error` statt bloßer String verworfen (`data-processor.ts`), damit die echte Ursache den `instanceof Error`-Check überlebt; `clearError()` gegen den beim Wiedereinstieg klebenden Fehler.
- Neues Fehlerklassen-Modell `shared/constants/wizard-error-classes.ts` (K1–K6) mit WHY/FIX/Zielschritt; Fallback für unbekannte Rohfehler; Hintergrund-Fehler → verwerfbare Warnungen.
- Wiederverwendbare Issue-Karte `shared/wizard-issue-card/` (Schweregrad-Icon, Klassen-Badge, WHY/FIX, einklappbare technische Details, „Fix in Schritt N"-Button, optional Dismiss).
- Step 5: persistenter Statusscreen mit fünf Zuständen (Review+Pre-flight, Processing, blockierender Fehler, Partial, Success), „Your work is saved"-Pill, Methoden-Statusleiste, „Fix in Schritt N"-Sprung über die A6-Logik + Toast; `ngOnInit` stellt Ergebnis/Fehler nach Wiedereinstieg wieder her (P-S5-02/03).
- Step 4: feldnahe Inline-Validierung (rote Meldung direkt unter den Nachbar-Parametern bei K4; Glyph-Panel flaggt „zu viele" >12).

### Manuelle Testschritte (Schritt → Location → Erwartung)
- CSV laden, Step 4 UMAP-Nachbarn ≥ Zeilenzahl, verarbeiten → Step 5: roter Hero + K4-Karte + „Fix in Schritt 4" springt zu Methoden mit Toast.
- Hintergrund-Methode scheitern lassen, FastMap ok → grünes Banner + amber „N von M" + verwerfbare Karte; Dismiss entfernt sie.
- Step 4 UMAP-Params, Nachbarn über Zeilenzahl → Inline-Fehler direkt unter dem Feld.
- Nach Fehler Wizard schließen + neu öffnen → Step 5 zeigt weiterhin den klassifizierten Fehler (kein Leerscreen); nach Erfolg + Neuöffnen → Ergebnis wiederhergestellt.
- Konstante/fast leere Spalte in der Projektion behalten → Review: amber Pre-flight-Banner + „Possible issue"-Karte.

Build: `npm run build` erfolgreich (nur vorbestehende Bundle-Budget-Warnung).
