### PR TITLE
feat(a4): Rueckgaengigmachen und Zuruecksetzen (Undo/Redo)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -136,6 +136,7 @@ Quick Wins ohne Abhängigkeit, die sich parallel zum Fundament wegräumen lassen
 ## A4 – Rückgängigmachen und Zurücksetzen anbieten
 **Typ:** Konzept · **Miro:** Historie einführen · **Status:** TODO · **Branch:** `feat/a4-undo-historie`
 **Befunde:** C-S1-02, C-S4-09, P-S3-01
+**Tests:** Automatisierte Tests für das Undo/Redo-Feature ergänzt (Testsuite grün).
 
 **Problem:** Folgenschwere Aktionen (erneuter Upload, Smart-Defaults-Klick, gesetzte Filter) sind nicht umkehrbar. Voraussetzung ist eine Aktionshistorie — im Code bisher **nicht vorhanden** (kein `undo`/`history` gefunden).
 

--- a/src/app/preprocessing-wizard/models/preprocessing-state.ts
+++ b/src/app/preprocessing-wizard/models/preprocessing-state.ts
@@ -42,6 +42,18 @@ export interface ProcessingProgress {
   message: string;
 }
 
+/**
+ * A4 – Undo/Redo. Status of the history stack, published so the wizard shell can
+ * enable/disable the toolbar buttons and show the concrete next action in the
+ * tooltip (e.g. "Rückgängig: Smart Defaults angewendet").
+ */
+export interface HistoryStatus {
+  canUndo: boolean;
+  canRedo: boolean;
+  undoLabel: string | null; // label of the action that Undo would revert
+  redoLabel: string | null; // label of the action that Redo would re-apply
+}
+
 export const DEFAULT_CLEANING_CONFIG: CleaningConfig = {
   removeDuplicates: false,
 };

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.html
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.html
@@ -23,6 +23,32 @@
     </aside>
 
     <div class="wizard-main">
+      <!-- A4: persistent undo/redo controls at the top of the work area. Curved
+           icons and a top-right position keep them visually distinct from the
+           Back/Weiter step navigation pinned to the bottom. -->
+      <div class="wizard-toolbar">
+        <button
+          class="btn-history"
+          type="button"
+          (click)="undo()"
+          [disabled]="!history.canUndo"
+          [title]="undoTooltip"
+          aria-label="Rückgängig"
+        >
+          <span class="material-icons">undo</span>
+        </button>
+        <button
+          class="btn-history"
+          type="button"
+          (click)="redo()"
+          [disabled]="!history.canRedo"
+          [title]="redoTooltip"
+          aria-label="Wiederherstellen"
+        >
+          <span class="material-icons">redo</span>
+        </button>
+      </div>
+
       <div class="wizard-content" #wizardContent>
         @if (error) {
           <div class="error-banner">
@@ -34,25 +60,27 @@
           </div>
         }
 
-        <div class="step-container">
-          @switch (currentStep) {
-            @case (0) {
-              <app-step1-upload></app-step1-upload>
+        @if (stepVisible) {
+          <div class="step-container">
+            @switch (currentStep) {
+              @case (0) {
+                <app-step1-upload></app-step1-upload>
+              }
+              @case (1) {
+                <app-step2-column-selection></app-step2-column-selection>
+              }
+              @case (2) {
+                <app-step3-configure-data-features></app-step3-configure-data-features>
+              }
+              @case (3) {
+                <app-step4-visualization-settings></app-step4-visualization-settings>
+              }
+              @case (4) {
+                <app-step5-review-processing (wizardFinish)="onWizardComplete()"></app-step5-review-processing>
+              }
             }
-            @case (1) {
-              <app-step2-column-selection></app-step2-column-selection>
-            }
-            @case (2) {
-              <app-step3-configure-data-features></app-step3-configure-data-features>
-            }
-            @case (3) {
-              <app-step4-visualization-settings></app-step4-visualization-settings>
-            }
-            @case (4) {
-              <app-step5-review-processing (wizardFinish)="onWizardComplete()"></app-step5-review-processing>
-            }
-          }
-        </div>
+          </div>
+        }
       </div>
 
       @if (activeStep(); as step) {

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.html
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.html
@@ -3,7 +3,7 @@
     <h1>Data Preprocessing Wizard</h1>
     <div class="header-actions">
       <button class="btn-icon" (click)="reset()" title="Start Over">
-        <span class="material-icons">refresh</span>
+        <span class="material-icons">delete</span>
       </button>
       <button class="btn-icon" (click)="closeWizard()" title="Close">
         <span class="material-icons">close</span>

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.html
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.html
@@ -35,7 +35,26 @@
           [title]="undoTooltip"
           aria-label="Rückgängig"
         >
-          <span class="material-icons">undo</span>
+          <!-- Undo/Redo als Inline-SVG statt Icon-Font, bewusst.
+               Gewünscht ist der kantige Haken-Pfeil aus dem "Material Symbols"-Stil.
+               Warum nicht die Icon-Font-Bibliothek genutzt wird:
+               1. Das Projekt bündelt lokal nur das klassische "Material Icons"-Paket;
+                  dessen "undo"-Glyph ist runder und trifft die gewünschte Form nicht.
+               2. Das passende "material-symbols"-Paket lässt sich hier nicht sauber
+                  ergänzen: node_modules ist eine geteilte Windows-Junction über alle
+                  Worktrees, ein "npm install" würde also das ganze Projekt verändern
+                  statt nur diesen Branch.
+               3. Die App läuft als GitHub Pages ohne Backend; das Nachladen des
+                  Symbols-Fonts von einem externen Google-Fonts-CDN würde eine
+                  Laufzeit-Fremdabhängigkeit einführen, die das Projekt vermeidet.
+               Daher: die offiziellen Material-Symbols-Pfade für undo/redo verbatim
+               inline (dependency-frei, exakt, nur auf diese zwei Buttons begrenzt);
+               redo ist die gespiegelte Form. -->
+          <svg class="history-icon" viewBox="0 -960 960 960" aria-hidden="true" focusable="false">
+            <path
+              d="M280-200v-80h284q63 0 109.5-40T720-420q0-60-46.5-100T564-560H312l104 104-56 56-200-200 200-200 56 56-104 104h252q97 0 166.5 63T800-420q0 94-69.5 157T564-200H280Z"
+            />
+          </svg>
         </button>
         <button
           class="btn-history"
@@ -45,7 +64,12 @@
           [title]="redoTooltip"
           aria-label="Wiederherstellen"
         >
-          <span class="material-icons">redo</span>
+          <!-- Gespiegelte Form (redo). -->
+          <svg class="history-icon" viewBox="0 -960 960 960" aria-hidden="true" focusable="false">
+            <path
+              d="M396-200q-97 0-166.5-63T160-420q0-94 69.5-157T396-640h252L544-744l56-56 200 200-200 200-56-56 104-104H396q-63 0-109.5 40T240-420q0 60 46.5 100T396-280h284v80H396Z"
+            />
+          </svg>
         </button>
       </div>
 
@@ -89,6 +113,22 @@
             <span class="material-icons">arrow_back</span>
             <span>Back</span>
           </button>
+
+          <!-- A4: dezenter Undo/Redo-Hinweis, mittig in die Navigationsleiste
+               eingebettet (kein schwebender Overlay-Toast). Nennt die geänderte
+               Einstellung und bietet den "Änderung anzeigen"-Deeplink. Single-Slot:
+               ein neuer Hinweis ersetzt den vorherigen. -->
+          @if (historyHint) {
+            <div class="history-hint" role="status">
+              <span class="material-icons">history</span>
+              <span class="history-hint-text">{{ historyHint.message }}</span>
+              @if (historyHint.step !== null && historyHint.anchorId) {
+                <button type="button" class="history-hint-action" (click)="showHistoryChange()">
+                  Änderung anzeigen
+                </button>
+              }
+            </div>
+          }
 
           <div class="buttons-right">
             @if (!step.canProceed() && step.disabledHint) {

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.scss
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.scss
@@ -108,8 +108,13 @@
     background-color 0.2s ease,
     color 0.2s ease;
 
-  .material-icons {
-    font-size: 1.25rem;
+  // Inline Material-Symbols-style undo/redo glyph. Inherits the button color via
+  // fill:currentColor so hover/disabled states apply without extra rules.
+  .history-icon {
+    width: 1.25rem;
+    height: 1.25rem;
+    display: block;
+    fill: currentColor;
   }
 
   &:hover:not(:disabled) {
@@ -188,6 +193,49 @@
     align-items: center;
     gap: 0.75rem;
     margin-left: auto;
+  }
+
+  // A4: dezenter Undo/Redo-Hinweis, mittig zwischen Back und Weiter. Nimmt den
+  // freien Mittelraum ein und zentriert seinen Inhalt, sodass die Navigations-
+  // buttons weder verschoben noch verdeckt werden; Text kürzt bei Platzmangel.
+  .history-hint {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.375rem;
+    padding: 0 0.75rem;
+    font-size: 0.8125rem;
+    color: v.$gray-600;
+
+    .material-icons {
+      font-size: 1rem;
+      color: v.$gray-500;
+      flex-shrink: 0;
+    }
+
+    .history-hint-text {
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .history-hint-action {
+      flex-shrink: 0;
+      background: none;
+      border: none;
+      padding: 0;
+      font: inherit;
+      font-weight: 600;
+      color: v.$status-info;
+      cursor: pointer;
+      text-decoration: underline;
+
+      &:hover {
+        color: v.$active-color;
+      }
+    }
   }
 
   .warning-message {

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.scss
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.scss
@@ -79,6 +79,50 @@
   min-height: 0;
 }
 
+// A4: undo/redo toolbar — a thin strip at the top of the work area, right-aligned.
+// Deliberately separated from the bottom step navigation (position + curved icons)
+// so it never reads as "Back/Next".
+.wizard-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.375rem 1rem;
+  background: v.$wizard-content-bg;
+  border-bottom: 1px solid v.$gray-200;
+  flex-shrink: 0;
+}
+
+.btn-history {
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  color: v.$status-info;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease;
+
+  .material-icons {
+    font-size: 1.25rem;
+  }
+
+  &:hover:not(:disabled) {
+    background: rgba(v.$active-color, 0.12);
+    border-color: rgba(v.$active-color, 0.4);
+  }
+
+  &:disabled {
+    color: v.$gray-400;
+    cursor: default;
+  }
+}
+
 .wizard-content {
   flex: 1;
   overflow-y: auto;

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.spec.ts
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.spec.ts
@@ -1,0 +1,234 @@
+import { TestBed } from '@angular/core/testing';
+import { PreprocessingWizardComponent } from './preprocessing-wizard.component';
+import { PreprocessingService } from './services/preprocessing.service';
+import { HistoryStatus, PreprocessingState } from './models/preprocessing-state';
+import { ColumnConfig } from './models/column-config';
+import {
+  DataType,
+  EncodingMethod,
+  ScalingMethod,
+  MissingValueStrategy,
+  OutlierMethod,
+  OutlierStrategy,
+} from './models/data-type.enum';
+
+/**
+ * A4 – wizard shell: the UX layer on top of the history engine. Covers the
+ * keyboard shortcuts (Strg+Z / Umschalt+Z / Y and the native-undo passthrough),
+ * the non-stacking history hint incl. its auto-dismiss timer and deep-link, the
+ * undo/redo tooltips, and the step-reload triggered by stateRestored$.
+ *
+ * The component uses viewChild(), which requires an injection context, so it is
+ * built via TestBed.runInInjectionContext rather than a bare `new` — this avoids
+ * rendering the (heavy) template while still giving the signal queries a context.
+ */
+describe('PreprocessingWizardComponent – undo/redo shell', () => {
+  let component: PreprocessingWizardComponent;
+  let service: PreprocessingService;
+
+  const dataProcessorStub = {} as unknown as ConstructorParameters<typeof PreprocessingService>[0];
+  const dataLoaderStub = {
+    getDataSetNames: () => [] as string[],
+  } as unknown as ConstructorParameters<typeof PreprocessingService>[1];
+
+  function makeConfig(name: string): ColumnConfig {
+    return {
+      name,
+      originalType: DataType.Numeric,
+      targetType: DataType.Numeric,
+      encodingMethod: EncodingMethod.Normalize,
+      scalingMethod: ScalingMethod.MinMax,
+      includeInProjection: true,
+      isColorFeature: false,
+      missingValueStrategy: MissingValueStrategy.Keep,
+      outlierMethod: OutlierMethod.IQR_1_5,
+      outlierStrategy: OutlierStrategy.Keep,
+      enabled: true,
+      hasIssues: false,
+    };
+  }
+
+  /** Seed columns so that toggleColumnEnabled produces a real, describable undo entry. */
+  function seedColumns(): void {
+    const columnConfigs = new Map<string, ColumnConfig>([['alpha', makeConfig('alpha')]]);
+    (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({ columnConfigs });
+  }
+
+  function makeKey(overrides: Partial<Record<'ctrlKey' | 'metaKey' | 'shiftKey', boolean>> & { key?: string; target?: EventTarget | null }): KeyboardEvent {
+    return {
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      key: 'z',
+      target: null,
+      preventDefault: jasmine.createSpy('preventDefault'),
+      ...overrides,
+    } as unknown as KeyboardEvent;
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    TestBed.configureTestingModule({});
+    service = new PreprocessingService(dataProcessorStub, dataLoaderStub);
+    seedColumns();
+    component = TestBed.runInInjectionContext(() => new PreprocessingWizardComponent(service));
+  });
+
+  afterEach(() => localStorage.clear());
+
+  describe('keyboard shortcuts', () => {
+    it('Strg+Z triggers undo and prevents default', () => {
+      spyOn(component, 'undo');
+      spyOn(component, 'redo');
+      const e = makeKey({ ctrlKey: true, key: 'z' });
+
+      component.onKeyDown(e);
+
+      expect(component.undo).toHaveBeenCalled();
+      expect(component.redo).not.toHaveBeenCalled();
+      expect(e.preventDefault).toHaveBeenCalled();
+    });
+
+    it('Strg+Umschalt+Z triggers redo', () => {
+      spyOn(component, 'undo');
+      spyOn(component, 'redo');
+
+      component.onKeyDown(makeKey({ ctrlKey: true, shiftKey: true, key: 'z' }));
+
+      expect(component.redo).toHaveBeenCalled();
+      expect(component.undo).not.toHaveBeenCalled();
+    });
+
+    it('Strg+Y triggers redo', () => {
+      spyOn(component, 'redo');
+      component.onKeyDown(makeKey({ ctrlKey: true, key: 'y' }));
+      expect(component.redo).toHaveBeenCalled();
+    });
+
+    it('accepts Cmd (metaKey) as the modifier too', () => {
+      spyOn(component, 'undo');
+      component.onKeyDown(makeKey({ metaKey: true, key: 'z' }));
+      expect(component.undo).toHaveBeenCalled();
+    });
+
+    it('ignores Z without a modifier', () => {
+      spyOn(component, 'undo');
+      const e = makeKey({ key: 'z' });
+      component.onKeyDown(e);
+      expect(component.undo).not.toHaveBeenCalled();
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+
+    it('ignores unrelated modifier combos (Strg+A)', () => {
+      spyOn(component, 'undo');
+      spyOn(component, 'redo');
+      component.onKeyDown(makeKey({ ctrlKey: true, key: 'a' }));
+      expect(component.undo).not.toHaveBeenCalled();
+      expect(component.redo).not.toHaveBeenCalled();
+    });
+
+    it('leaves native field-level undo alone when focus is in an input', () => {
+      spyOn(component, 'undo');
+      const input = document.createElement('input');
+      const e = makeKey({ ctrlKey: true, key: 'z', target: input });
+
+      component.onKeyDown(e);
+
+      expect(component.undo).not.toHaveBeenCalled();
+      expect(e.preventDefault).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('history hint', () => {
+    it('shows a named hint after an undo', () => {
+      service.toggleColumnEnabled('alpha'); // one undoable action, labelled "Spaltenauswahl"
+      component.undo();
+
+      expect(component.historyHint).not.toBeNull();
+      expect(component.historyHint!.message).toBe('Spaltenauswahl wurde zurückgesetzt');
+      expect(component.historyHint!.step).toBe(1);
+      expect(component.historyHint!.anchorId).toBe('wizard-anchor-columns');
+    });
+
+    it('uses "wiederhergestellt" wording after a redo', () => {
+      service.toggleColumnEnabled('alpha');
+      service.undo();
+      component.redo();
+
+      expect(component.historyHint!.message).toBe('Spaltenauswahl wurde wiederhergestellt');
+    });
+
+    it('shows no hint when there is nothing to undo', () => {
+      component.undo();
+      expect(component.historyHint).toBeNull();
+    });
+
+    it('keeps only the latest hint (non-stacking)', () => {
+      service.updateColumnConfig('alpha', { encodingMethod: EncodingMethod.Standardize });
+      service.toggleColumnEnabled('alpha');
+
+      component.undo(); // reverts the toggle -> "Spaltenauswahl"
+      component.undo(); // reverts the encoding change -> "Encoding"
+
+      expect(component.historyHint!.message).toBe('Encoding wurde zurückgesetzt');
+    });
+
+    it('auto-dismisses the hint after the timeout', () => {
+      jasmine.clock().install();
+      try {
+        service.toggleColumnEnabled('alpha');
+        component.undo();
+        expect(component.historyHint).not.toBeNull();
+
+        jasmine.clock().tick(5001);
+        expect(component.historyHint).toBeNull();
+      } finally {
+        jasmine.clock().uninstall();
+      }
+    });
+
+    it('deep-links to the changed setting and dismisses on showHistoryChange', () => {
+      const spy = spyOn(service, 'goToStepWithScroll');
+      service.toggleColumnEnabled('alpha');
+      component.undo();
+
+      component.showHistoryChange();
+
+      expect(spy).toHaveBeenCalledWith(1, 'wizard-anchor-columns');
+      expect(component.historyHint).toBeNull();
+    });
+  });
+
+  describe('tooltips', () => {
+    it('describes the concrete next undo/redo action when available', () => {
+      component.history = { canUndo: true, canRedo: true, undoLabel: 'Spalte abgewählt', redoLabel: 'Spalte ausgewählt' } as HistoryStatus;
+      expect(component.undoTooltip).toBe('Rückgängig: Spalte abgewählt');
+      expect(component.redoTooltip).toBe('Wiederherstellen: Spalte ausgewählt');
+    });
+
+    it('falls back to an empty-state message', () => {
+      component.history = { canUndo: false, canRedo: false, undoLabel: null, redoLabel: null };
+      expect(component.undoTooltip).toBe('Nichts rückgängig zu machen');
+      expect(component.redoTooltip).toBe('Nichts wiederherzustellen');
+    });
+  });
+
+  describe('step reload on stateRestored$', () => {
+    it('re-instantiates the visible step after an undo restores a snapshot', () => {
+      jasmine.clock().install();
+      try {
+        component.ngOnInit();
+        service.toggleColumnEnabled('alpha');
+
+        service.undo(); // emits stateRestored$ -> reloadCurrentStep()
+        expect(component.stepVisible).toBeFalse();
+
+        jasmine.clock().tick(1);
+        expect(component.stepVisible).toBeTrue();
+      } finally {
+        jasmine.clock().uninstall();
+        component.ngOnDestroy();
+      }
+    });
+  });
+});

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.ts
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.ts
@@ -1,6 +1,17 @@
-import { Component, OnInit, OnDestroy, Output, EventEmitter, ViewChild, ElementRef, viewChild } from '@angular/core';
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  Output,
+  EventEmitter,
+  ViewChild,
+  ElementRef,
+  viewChild,
+  HostListener,
+} from '@angular/core';
 import { Subscription, distinctUntilChanged, map } from 'rxjs';
 import { PreprocessingService } from './services/preprocessing.service';
+import { HistoryStatus } from './models/preprocessing-state';
 import { ProgressStepperComponent, Step } from './shared/progress-stepper/progress-stepper.component';
 import { WIZARD_STEP } from './shared/wizard-step';
 import { STEP_INFO } from './shared/constants/step-info';
@@ -40,6 +51,12 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
   highestStepVisited = 0; // Track highest step to enable forward navigation
   isProcessing = false;
   error: string | null = null;
+
+  // A4: undo/redo history state, driven by the service's history$ stream.
+  history: HistoryStatus = { canUndo: false, canRedo: false, undoLabel: null, redoLabel: null };
+  // Toggled off/on to force the current step to re-instantiate after an undo/redo,
+  // so steps that cache state in ngOnInit re-read the restored snapshot.
+  stepVisible = true;
 
   // Labels and descriptions come from STEP_INFO so the sidebar stays the single
   // source of truth for step titles/purposes (no duplication in the work area).
@@ -83,6 +100,82 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
           this.scrollToTop();
         })
     );
+
+    // A4: keep the undo/redo toolbar in sync with the history stack.
+    this.subscription.add(
+      this.preprocessingService.history$.subscribe(status => {
+        this.history = status;
+      })
+    );
+
+    // A4: after an undo/redo reinstalls a snapshot, force the visible step to
+    // rebuild so it reflects the restored state (steps read state once on init).
+    this.subscription.add(
+      this.preprocessingService.stateRestored$.subscribe(() => {
+        this.reloadCurrentStep();
+      })
+    );
+  }
+
+  // ── A4: Undo/Redo ─────────────────────────────────────────────────────────
+
+  undo(): void {
+    this.preprocessingService.undo();
+  }
+
+  redo(): void {
+    this.preprocessingService.redo();
+  }
+
+  get undoTooltip(): string {
+    return this.history.canUndo && this.history.undoLabel
+      ? `Rückgängig: ${this.history.undoLabel}`
+      : 'Nichts rückgängig zu machen';
+  }
+
+  get redoTooltip(): string {
+    return this.history.canRedo && this.history.redoLabel
+      ? `Wiederherstellen: ${this.history.redoLabel}`
+      : 'Nichts wiederherzustellen';
+  }
+
+  /**
+   * Global wizard shortcuts: Strg+Z = undo, Strg+Umschalt+Z (or Strg+Y) = redo.
+   * When focus is inside a text input/textarea/contenteditable we do nothing and
+   * let the browser's native field-level undo run instead.
+   */
+  @HostListener('document:keydown', ['$event'])
+  onKeyDown(event: KeyboardEvent): void {
+    const ctrl = event.ctrlKey || event.metaKey;
+    if (!ctrl) return;
+
+    const key = event.key.toLowerCase();
+    const isUndo = key === 'z' && !event.shiftKey;
+    const isRedo = (key === 'z' && event.shiftKey) || key === 'y';
+    if (!isUndo && !isRedo) return;
+
+    if (this.isEditableTarget(event.target)) return;
+
+    event.preventDefault();
+    if (isRedo) {
+      this.redo();
+    } else {
+      this.undo();
+    }
+  }
+
+  private isEditableTarget(target: EventTarget | null): boolean {
+    const el = target as HTMLElement | null;
+    if (!el) return false;
+    const tag = el.tagName;
+    return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT' || el.isContentEditable;
+  }
+
+  private reloadCurrentStep(): void {
+    this.stepVisible = false;
+    setTimeout(() => {
+      this.stepVisible = true;
+    }, 0);
   }
 
   private scrollToTop(): void {

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.ts
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.ts
@@ -12,7 +12,6 @@ import {
 import { Subscription, distinctUntilChanged, map } from 'rxjs';
 import { PreprocessingService, UndoRedoInfo } from './services/preprocessing.service';
 import { HistoryStatus } from './models/preprocessing-state';
-import { ToastService } from '../services/toast.service';
 import { ProgressStepperComponent, Step } from './shared/progress-stepper/progress-stepper.component';
 import { WIZARD_STEP } from './shared/wizard-step';
 import { STEP_INFO } from './shared/constants/step-info';
@@ -59,6 +58,13 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
   // so steps that cache state in ngOnInit re-read the restored snapshot.
   stepVisible = true;
 
+  // A4: dezenter Undo/Redo-Hinweis, in die untere Navigationsleiste eingebettet
+  // (statt eines schwebenden Toasts). Single-Slot: ein neuer Hinweis ersetzt den
+  // vorherigen, ein Timer blendet ihn nach kurzer Zeit wieder aus.
+  historyHint: { message: string; step: number | null; anchorId: string | null } | null = null;
+  private historyHintTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly HISTORY_HINT_MS = 5000;
+
   // Labels and descriptions come from STEP_INFO so the sidebar stays the single
   // source of truth for step titles/purposes (no duplication in the work area).
   steps: Step[] = Object.keys(STEP_INFO)
@@ -70,10 +76,7 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
       completed: false,
     }));
 
-  constructor(
-    private preprocessingService: PreprocessingService,
-    private toastService: ToastService
-  ) {}
+  constructor(private preprocessingService: PreprocessingService) {}
 
   ngOnInit(): void {
     // Subscribe to state changes
@@ -126,32 +129,51 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
   undo(): void {
     const info = this.preprocessingService.undo();
     if (info) {
-      this.showHistoryToast(info, 'zurückgesetzt');
+      this.showHistoryHint(info, 'zurückgesetzt');
     }
   }
 
   redo(): void {
     const info = this.preprocessingService.redo();
     if (info) {
-      this.showHistoryToast(info, 'wiederhergestellt');
+      this.showHistoryHint(info, 'wiederhergestellt');
     }
   }
 
   /**
-   * A4: dezenter, nicht stapelnder Toast nach Undo/Redo. Nennt die konkret geänderte
-   * Einstellung und bietet – sofern ein Zielanker bekannt ist – eine "Änderung
-   * anzeigen"-Aktion, die direkt zum betroffenen Feld springt.
+   * A4: zeigt einen dezenten, nicht stapelnden Hinweis in der Navigationsleiste.
+   * Nennt die konkret geänderte Einstellung; der Timer blendet ihn wieder aus.
    */
-  private showHistoryToast(info: UndoRedoInfo, verb: 'zurückgesetzt' | 'wiederhergestellt'): void {
-    const message = `${info.settingLabel} wurde ${verb}`;
-    const action =
-      info.step !== null && info.anchorId
-        ? {
-            label: 'Änderung anzeigen',
-            handler: () => this.preprocessingService.goToStepWithScroll(info.step as number, info.anchorId as string),
-          }
-        : undefined;
-    this.toastService.showUndoRedo(message, action);
+  private showHistoryHint(info: UndoRedoInfo, verb: 'zurückgesetzt' | 'wiederhergestellt'): void {
+    this.historyHint = {
+      message: `${info.settingLabel} wurde ${verb}`,
+      step: info.step,
+      anchorId: info.anchorId,
+    };
+    if (this.historyHintTimer) {
+      clearTimeout(this.historyHintTimer);
+    }
+    this.historyHintTimer = setTimeout(() => {
+      this.historyHint = null;
+      this.historyHintTimer = null;
+    }, this.HISTORY_HINT_MS);
+  }
+
+  /** Deep-link from the hint to the changed setting, then dismiss the hint. */
+  showHistoryChange(): void {
+    const hint = this.historyHint;
+    if (hint && hint.step !== null && hint.anchorId) {
+      this.preprocessingService.goToStepWithScroll(hint.step, hint.anchorId);
+    }
+    this.dismissHistoryHint();
+  }
+
+  private dismissHistoryHint(): void {
+    this.historyHint = null;
+    if (this.historyHintTimer) {
+      clearTimeout(this.historyHintTimer);
+      this.historyHintTimer = null;
+    }
   }
 
   get undoTooltip(): string {
@@ -219,6 +241,9 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.subscription.unsubscribe();
+    if (this.historyHintTimer) {
+      clearTimeout(this.historyHintTimer);
+    }
   }
 
   private updateStepCompletion(state: PreprocessingState): void {

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.ts
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.ts
@@ -10,8 +10,9 @@ import {
   HostListener,
 } from '@angular/core';
 import { Subscription, distinctUntilChanged, map } from 'rxjs';
-import { PreprocessingService } from './services/preprocessing.service';
+import { PreprocessingService, UndoRedoInfo } from './services/preprocessing.service';
 import { HistoryStatus } from './models/preprocessing-state';
+import { ToastService } from '../services/toast.service';
 import { ProgressStepperComponent, Step } from './shared/progress-stepper/progress-stepper.component';
 import { WIZARD_STEP } from './shared/wizard-step';
 import { STEP_INFO } from './shared/constants/step-info';
@@ -69,7 +70,10 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
       completed: false,
     }));
 
-  constructor(private preprocessingService: PreprocessingService) {}
+  constructor(
+    private preprocessingService: PreprocessingService,
+    private toastService: ToastService
+  ) {}
 
   ngOnInit(): void {
     // Subscribe to state changes
@@ -120,11 +124,34 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
   // ── A4: Undo/Redo ─────────────────────────────────────────────────────────
 
   undo(): void {
-    this.preprocessingService.undo();
+    const info = this.preprocessingService.undo();
+    if (info) {
+      this.showHistoryToast(info, 'zurückgesetzt');
+    }
   }
 
   redo(): void {
-    this.preprocessingService.redo();
+    const info = this.preprocessingService.redo();
+    if (info) {
+      this.showHistoryToast(info, 'wiederhergestellt');
+    }
+  }
+
+  /**
+   * A4: dezenter, nicht stapelnder Toast nach Undo/Redo. Nennt die konkret geänderte
+   * Einstellung und bietet – sofern ein Zielanker bekannt ist – eine "Änderung
+   * anzeigen"-Aktion, die direkt zum betroffenen Feld springt.
+   */
+  private showHistoryToast(info: UndoRedoInfo, verb: 'zurückgesetzt' | 'wiederhergestellt'): void {
+    const message = `${info.settingLabel} wurde ${verb}`;
+    const action =
+      info.step !== null && info.anchorId
+        ? {
+            label: 'Änderung anzeigen',
+            handler: () => this.preprocessingService.goToStepWithScroll(info.step as number, info.anchorId as string),
+          }
+        : undefined;
+    this.toastService.showUndoRedo(message, action);
   }
 
   get undoTooltip(): string {

--- a/src/app/preprocessing-wizard/services/preprocessing.service.spec.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.spec.ts
@@ -1,0 +1,310 @@
+import { PreprocessingService } from './preprocessing.service';
+import { HistoryStatus, PreprocessingState } from '../models/preprocessing-state';
+import { ColumnConfig } from '../models/column-config';
+import { DataProfile, ColumnStatistics } from '../models/column-statistics';
+import {
+  DataType,
+  EncodingMethod,
+  ScalingMethod,
+  MissingValueStrategy,
+  OutlierMethod,
+  OutlierStrategy,
+} from '../models/data-type.enum';
+
+/**
+ * A4 – Undo/Redo history engine.
+ *
+ * These tests drive the history stack directly on the service (the single source
+ * of truth for undo/redo). They pin the invariants the wizard shell and the step
+ * components rely on: LIFO ordering, redo-stack invalidation, snapshot isolation
+ * (deep copy), the MAX_HISTORY cap, the diff-based settingLabel/deep-link mapping,
+ * and the cross-field cleanup that must undo as one atomic action.
+ */
+describe('PreprocessingService – Undo/Redo history', () => {
+  let service: PreprocessingService;
+
+  // Minimal stubs: the history engine never touches the worker or the data loader.
+  const dataProcessorStub = {} as unknown as ConstructorParameters<typeof PreprocessingService>[0];
+  const dataLoaderStub = {
+    getDataSetNames: () => [] as string[],
+  } as unknown as ConstructorParameters<typeof PreprocessingService>[1];
+
+  function makeColumn(name: string, dataType: DataType): ColumnStatistics {
+    return {
+      name,
+      dataType,
+      count: 100,
+      missingCount: 0,
+      missingPercentage: 0,
+      uniqueCount: 50,
+      mean: 10,
+      stdDev: 2,
+    };
+  }
+
+  function makeConfig(name: string, overrides: Partial<ColumnConfig> = {}): ColumnConfig {
+    return {
+      name,
+      originalType: DataType.Numeric,
+      targetType: DataType.Numeric,
+      encodingMethod: EncodingMethod.Normalize,
+      scalingMethod: ScalingMethod.MinMax,
+      includeInProjection: true,
+      isColorFeature: false,
+      missingValueStrategy: MissingValueStrategy.Keep,
+      outlierMethod: OutlierMethod.IQR_1_5,
+      outlierStrategy: OutlierStrategy.Keep,
+      enabled: true,
+      hasIssues: false,
+      ...overrides,
+    };
+  }
+
+  /** Seed the service with a realistic loaded-file state without running the worker. */
+  function seed(overrides: Partial<PreprocessingState> = {}): void {
+    const columns = ['alpha', 'beta', 'gamma'].map(n => makeColumn(n, DataType.Numeric));
+    const profile: DataProfile = {
+      totalRows: 100,
+      totalColumns: columns.length,
+      fileSize: 1000,
+      fileName: 'test.csv',
+      columns,
+      qualityScore: 90,
+      duplicateCount: 0,
+      previewRows: [],
+    };
+    const columnConfigs = new Map<string, ColumnConfig>();
+    columns.forEach(c => columnConfigs.set(c.name, makeConfig(c.name)));
+
+    // updateState is private but is the honest way to install a base state in a test.
+    (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({
+      rawFileName: 'test.csv',
+      dataProfile: profile,
+      columnConfigs,
+      datasetName: 'test',
+      ...overrides,
+    });
+  }
+
+  function latestHistory(): HistoryStatus {
+    let status!: HistoryStatus;
+    service.history$.subscribe(s => (status = s)).unsubscribe();
+    return status;
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    service = new PreprocessingService(dataProcessorStub, dataLoaderStub);
+    seed();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe('empty history', () => {
+    it('starts with nothing to undo or redo', () => {
+      const status = latestHistory();
+      expect(status.canUndo).toBeFalse();
+      expect(status.canRedo).toBeFalse();
+      expect(status.undoLabel).toBeNull();
+      expect(status.redoLabel).toBeNull();
+      expect(service.canUndo).toBeFalse();
+      expect(service.canRedo).toBeFalse();
+    });
+
+    it('undo() and redo() return null and change nothing on an empty stack', () => {
+      const before = service.currentState;
+      expect(service.undo()).toBeNull();
+      expect(service.redo()).toBeNull();
+      expect(service.currentState).toBe(before);
+    });
+  });
+
+  describe('pushHistory', () => {
+    it('makes undo available and reports the action label', () => {
+      service.pushHistory('Aktion A');
+      const status = latestHistory();
+      expect(status.canUndo).toBeTrue();
+      expect(status.undoLabel).toBe('Aktion A');
+      expect(status.canRedo).toBeFalse();
+    });
+
+    it('caps the undo stack at MAX_HISTORY (50) entries', () => {
+      for (let i = 0; i < 60; i++) {
+        service.pushHistory(`Aktion ${i}`);
+      }
+      const stackLen = (service as unknown as { undoStack: unknown[] }).undoStack.length;
+      expect(stackLen).toBe(50);
+      // The oldest entries were dropped, the newest survives.
+      expect(latestHistory().undoLabel).toBe('Aktion 59');
+    });
+  });
+
+  describe('undo / redo round trip', () => {
+    it('reverts a column-enable toggle and re-applies it', () => {
+      service.toggleColumnEnabled('alpha'); // disable
+      expect(service.currentState.columnConfigs.get('alpha')!.enabled).toBeFalse();
+
+      const undoInfo = service.undo();
+      expect(undoInfo).not.toBeNull();
+      expect(service.currentState.columnConfigs.get('alpha')!.enabled).toBeTrue();
+
+      const redoInfo = service.redo();
+      expect(redoInfo).not.toBeNull();
+      expect(service.currentState.columnConfigs.get('alpha')!.enabled).toBeFalse();
+    });
+
+    it('reverts and re-applies a glyph-feature change', () => {
+      service.pushHistory('Glyph-Merkmale geändert');
+      service.setGlyphFeatures(['alpha', 'beta', 'gamma']);
+      expect(service.currentState.glyphFeatures).toEqual(['alpha', 'beta', 'gamma']);
+
+      service.undo();
+      expect(service.currentState.glyphFeatures).toEqual([]);
+
+      service.redo();
+      expect(service.currentState.glyphFeatures).toEqual(['alpha', 'beta', 'gamma']);
+    });
+
+    it('unwinds several actions in strict LIFO order', () => {
+      service.updateColumnConfig('alpha', { encodingMethod: EncodingMethod.Standardize });
+      service.updateColumnConfig('beta', { encodingMethod: EncodingMethod.Standardize });
+
+      // Undo the beta change first (most recent), then alpha.
+      service.undo();
+      expect(service.currentState.columnConfigs.get('beta')!.encodingMethod).toBe(EncodingMethod.Normalize);
+      expect(service.currentState.columnConfigs.get('alpha')!.encodingMethod).toBe(EncodingMethod.Standardize);
+
+      service.undo();
+      expect(service.currentState.columnConfigs.get('alpha')!.encodingMethod).toBe(EncodingMethod.Normalize);
+    });
+
+    it('keeps undo/redo labels in sync with the stacks', () => {
+      service.pushHistory('Aktion A');
+      service.pushHistory('Aktion B');
+      expect(latestHistory().undoLabel).toBe('Aktion B');
+
+      service.undo();
+      const afterUndo = latestHistory();
+      expect(afterUndo.undoLabel).toBe('Aktion A');
+      expect(afterUndo.redoLabel).toBe('Aktion B');
+      expect(afterUndo.canRedo).toBeTrue();
+    });
+  });
+
+  describe('redo-stack invalidation', () => {
+    it('clears the redo stack when a new action is pushed after an undo', () => {
+      service.pushHistory('Aktion A');
+      service.undo();
+      expect(latestHistory().canRedo).toBeTrue();
+
+      service.pushHistory('Aktion B');
+      const status = latestHistory();
+      expect(status.canRedo).toBeFalse();
+      expect(service.redo()).toBeNull();
+    });
+  });
+
+  describe('snapshot isolation', () => {
+    it('deep-copies column configs so a later in-place mutation cannot corrupt a snapshot', () => {
+      service.pushHistory('Vor Mutation');
+      // Mutate the live config object in place, bypassing the public API entirely.
+      const liveConfig = service.currentState.columnConfigs.get('alpha')!;
+      liveConfig.encodingMethod = EncodingMethod.Standardize;
+
+      service.undo();
+      // The snapshot must still hold the pre-mutation value.
+      expect(service.currentState.columnConfigs.get('alpha')!.encodingMethod).toBe(EncodingMethod.Normalize);
+    });
+
+    it('deep-copies glyph feature arrays', () => {
+      service.setGlyphFeatures(['alpha', 'beta', 'gamma']);
+      service.pushHistory('Vor Mutation');
+      // Push directly onto the live array reference.
+      service.currentState.glyphFeatures.push('delta');
+
+      service.undo();
+      expect(service.currentState.glyphFeatures).toEqual(['alpha', 'beta', 'gamma']);
+    });
+  });
+
+  describe('describeDiff – setting label and deep-link mapping', () => {
+    it('names an encoding change and points to step 3 (Datenkonfiguration)', () => {
+      service.updateColumnConfig('alpha', { encodingMethod: EncodingMethod.Standardize });
+      const info = service.undo()!;
+      expect(info.settingLabel).toBe('Encoding');
+      expect(info.step).toBe(2);
+      expect(info.anchorId).toBe('wizard-anchor-features');
+    });
+
+    it('names a glyph-feature change and points to step 4 (Visualisierung)', () => {
+      service.pushHistory('Glyph-Merkmale geändert');
+      service.setGlyphFeatures(['alpha', 'beta', 'gamma']);
+      const info = service.undo()!;
+      expect(info.settingLabel).toBe('Glyph-Merkmale');
+      expect(info.step).toBe(3);
+      expect(info.anchorId).toBe('wizard-anchor-glyph');
+    });
+
+    it('names a column-selection change', () => {
+      service.toggleColumnEnabled('alpha');
+      const info = service.undo()!;
+      expect(info.settingLabel).toBe('Spaltenauswahl');
+      expect(info.step).toBe(1);
+    });
+
+    it('falls back to the raw action label when no field maps cleanly', () => {
+      // Push twice over an identical state so the diff finds no changed field.
+      service.pushHistory('Freitext-Aktion');
+      const info = service.undo()!;
+      expect(info.actionLabel).toBe('Freitext-Aktion');
+      expect(info.settingLabel).toBe('Freitext-Aktion');
+      expect(info.step).toBeNull();
+    });
+  });
+
+  describe('cross-field cleanup is atomic under undo', () => {
+    it('restores the color feature, color scale AND glyph mapping with a single undo', () => {
+      // alpha is the color feature; glyph rays reference alpha + beta.
+      seed();
+      const configs = service.currentState.columnConfigs;
+      configs.get('alpha')!.isColorFeature = true;
+      (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({
+        columnConfigs: new Map(configs),
+        colorScaleId: 2,
+        colorScaleMode: 'continuous',
+        glyphFeatures: ['alpha', 'beta'],
+      });
+
+      // Disabling alpha must cascade: clear color feature, reset scale, drop alpha from glyph.
+      service.toggleColumnEnabled('alpha');
+      expect(service.currentState.columnConfigs.get('alpha')!.isColorFeature).toBeFalse();
+      expect(service.currentState.colorScaleId).toBe(0);
+      expect(service.currentState.glyphFeatures).toEqual(['beta']);
+
+      // A single undo reverts the toggle and the whole cascade together.
+      service.undo();
+      const restored = service.currentState;
+      expect(restored.columnConfigs.get('alpha')!.enabled).toBeTrue();
+      expect(restored.columnConfigs.get('alpha')!.isColorFeature).toBeTrue();
+      expect(restored.colorScaleId).toBe(2);
+      expect(restored.glyphFeatures).toEqual(['alpha', 'beta']);
+    });
+  });
+
+  describe('resetState', () => {
+    it('clears both history stacks', () => {
+      service.pushHistory('Aktion A');
+      service.pushHistory('Aktion B');
+      service.undo();
+      expect(latestHistory().canUndo).toBeTrue();
+      expect(latestHistory().canRedo).toBeTrue();
+
+      service.resetState();
+      const status = latestHistory();
+      expect(status.canUndo).toBeFalse();
+      expect(status.canRedo).toBeFalse();
+    });
+  });
+});

--- a/src/app/preprocessing-wizard/services/preprocessing.service.spec.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.spec.ts
@@ -307,4 +307,156 @@ describe('PreprocessingService – Undo/Redo history', () => {
       expect(status.canRedo).toBeFalse();
     });
   });
+
+  describe('describeDiff – full SETTING_META mapping', () => {
+    // Change exactly one field, then undo, and check the reported setting/deep-link.
+    // pushHistory snapshots the pre-change state; the single mutation is the only diff.
+    function undoInfoAfter(mutate: () => void) {
+      service.pushHistory('irgendeine Aktion');
+      mutate();
+      return service.undo()!;
+    }
+
+    function mutateColumn<K extends keyof ColumnConfig>(field: K, value: ColumnConfig[K]): void {
+      const configs = new Map(service.currentState.columnConfigs);
+      configs.set('alpha', { ...configs.get('alpha')!, [field]: value });
+      (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({ columnConfigs: configs });
+    }
+
+    function setTop(updates: Partial<PreprocessingState>): void {
+      (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState(updates);
+    }
+
+    const cases: { name: string; mutate: () => void; label: string; step: number | null; anchor: string | null }[] = [
+      { name: 'rawFileName', mutate: () => setTop({ rawFileName: 'anders.csv' }), label: 'Datei', step: 0, anchor: null },
+      { name: 'datasetName', mutate: () => setTop({ datasetName: 'umbenannt' }), label: 'Datensatzname', step: 0, anchor: null },
+      { name: 'columnConfigs.enabled', mutate: () => mutateColumn('enabled', false), label: 'Spaltenauswahl', step: 1, anchor: 'wizard-anchor-columns' },
+      { name: 'columnConfigs.isColorFeature', mutate: () => mutateColumn('isColorFeature', true), label: 'Farbattribut', step: 3, anchor: 'wizard-anchor-color' },
+      { name: 'columnConfigs.targetType', mutate: () => mutateColumn('targetType', DataType.Categorical), label: 'Datentyp', step: 2, anchor: 'wizard-anchor-features' },
+      { name: 'columnConfigs.encodingMethod', mutate: () => mutateColumn('encodingMethod', EncodingMethod.Standardize), label: 'Encoding', step: 2, anchor: 'wizard-anchor-features' },
+      { name: 'columnConfigs.scalingMethod', mutate: () => mutateColumn('scalingMethod', ScalingMethod.Standard), label: 'Skalierung', step: 2, anchor: 'wizard-anchor-features' },
+      { name: 'columnConfigs.includeInProjection', mutate: () => mutateColumn('includeInProjection', false), label: 'Projektionsspalten', step: 3, anchor: 'wizard-anchor-projection-columns' },
+      { name: 'columnConfigs.missingValueStrategy', mutate: () => mutateColumn('missingValueStrategy', MissingValueStrategy.FillMean), label: 'Fehlende Werte', step: 2, anchor: 'wizard-anchor-features' },
+      { name: 'columnConfigs.outlierStrategy', mutate: () => mutateColumn('outlierStrategy', OutlierStrategy.Remove), label: 'Ausreißerbehandlung', step: 2, anchor: 'wizard-anchor-features' },
+      { name: 'cleaningConfig', mutate: () => setTop({ cleaningConfig: { removeDuplicates: true } }), label: 'Datenbereinigung', step: 2, anchor: 'wizard-anchor-cleaning' },
+      { name: 'projectionConfig', mutate: () => setTop({ projectionConfig: { ...service.currentState.projectionConfig, enablePCA: false } }), label: 'Projektionsparameter', step: 3, anchor: 'wizard-anchor-methods' },
+      { name: 'glyphFeatures', mutate: () => setTop({ glyphFeatures: ['alpha'] }), label: 'Glyph-Merkmale', step: 3, anchor: 'wizard-anchor-glyph' },
+      { name: 'tooltipFeatures', mutate: () => setTop({ tooltipFeatures: ['alpha'] }), label: 'Tooltip-Merkmale', step: 3, anchor: 'wizard-anchor-glyph' },
+      { name: 'colorScaleMode', mutate: () => setTop({ colorScaleMode: 'categorical' }), label: 'Farbmodus', step: 3, anchor: 'wizard-anchor-color' },
+      { name: 'colorScaleId', mutate: () => setTop({ colorScaleId: 5 }), label: 'Farbskala', step: 3, anchor: 'wizard-anchor-color' },
+    ];
+
+    cases.forEach(c => {
+      it(`maps a ${c.name} change to "${c.label}" (step ${c.step})`, () => {
+        const info = undoInfoAfter(c.mutate);
+        expect(info.settingLabel).toBe(c.label);
+        expect(info.step).toBe(c.step);
+        expect(info.anchorId).toBe(c.anchor);
+      });
+    });
+
+    it('treats an added/removed column as a selection change', () => {
+      service.pushHistory('irgendeine Aktion');
+      const configs = new Map(service.currentState.columnConfigs);
+      configs.delete('gamma');
+      (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({ columnConfigs: configs });
+      const info = service.undo()!;
+      expect(info.settingLabel).toBe('Spaltenauswahl');
+    });
+  });
+
+  describe('round trips for the remaining undoable actions', () => {
+    it('setColumnsEnabled reverts a bulk disable', () => {
+      service.setColumnsEnabled(['alpha', 'beta'], false);
+      expect(service.currentState.columnConfigs.get('alpha')!.enabled).toBeFalse();
+      expect(service.currentState.columnConfigs.get('beta')!.enabled).toBeFalse();
+
+      service.undo();
+      expect(service.currentState.columnConfigs.get('alpha')!.enabled).toBeTrue();
+      expect(service.currentState.columnConfigs.get('beta')!.enabled).toBeTrue();
+    });
+
+    it('selectAllColumns undo restores a previously disabled column', () => {
+      service.setColumnsEnabled(['alpha'], false);
+      service.selectAllColumns();
+      expect(service.currentState.columnConfigs.get('alpha')!.enabled).toBeTrue();
+
+      service.undo(); // revert selectAll
+      expect(service.currentState.columnConfigs.get('alpha')!.enabled).toBeFalse();
+    });
+
+    it('deselectAllColumns is fully reversible', () => {
+      service.deselectAllColumns();
+      const allDisabled = Array.from(service.currentState.columnConfigs.values()).every(c => !c.enabled);
+      expect(allDisabled).toBeTrue();
+
+      service.undo();
+      const allEnabled = Array.from(service.currentState.columnConfigs.values()).every(c => c.enabled);
+      expect(allEnabled).toBeTrue();
+    });
+
+    it('updateCleaningConfig round trip', () => {
+      expect(service.currentState.cleaningConfig.removeDuplicates).toBeFalse();
+      service.updateCleaningConfig({ removeDuplicates: true });
+      expect(service.currentState.cleaningConfig.removeDuplicates).toBeTrue();
+
+      service.undo();
+      expect(service.currentState.cleaningConfig.removeDuplicates).toBeFalse();
+    });
+
+    it('updateProjectionConfig round trip', () => {
+      expect(service.currentState.projectionConfig.enablePCA).toBeTrue();
+      service.updateProjectionConfig({ enablePCA: false });
+      expect(service.currentState.projectionConfig.enablePCA).toBeFalse();
+
+      service.undo();
+      expect(service.currentState.projectionConfig.enablePCA).toBeTrue();
+    });
+  });
+
+  describe('file load history', () => {
+    const profile: DataProfile = {
+      totalRows: 2,
+      totalColumns: 0,
+      fileSize: 10,
+      fileName: 'x.csv',
+      columns: [] as ColumnStatistics[],
+      qualityScore: 100,
+      duplicateCount: 0,
+      previewRows: [],
+    };
+
+    function serviceWithLoader() {
+      const proc = { profileData: async () => profile } as unknown as ConstructorParameters<typeof PreprocessingService>[0];
+      return new PreprocessingService(proc, dataLoaderStub);
+    }
+
+    function csvFile(): File {
+      return new File(['a,b\n1,2\n'], 'daten.csv', { type: 'text/csv' });
+    }
+
+    it('records the first load as "Datei geladen" and undo clears the profile', async () => {
+      const svc = serviceWithLoader();
+      await svc.loadCSV(csvFile());
+
+      expect(svc.currentState.dataProfile).not.toBeNull();
+      expect(svc.canUndo).toBeTrue();
+      let status!: HistoryStatus;
+      svc.history$.subscribe(s => (status = s)).unsubscribe();
+      expect(status.undoLabel).toBe('Datei geladen');
+
+      svc.undo();
+      expect(svc.currentState.dataProfile).toBeNull();
+    });
+
+    it('labels a re-upload as "Datei ersetzt"', async () => {
+      const svc = serviceWithLoader();
+      await svc.loadCSV(csvFile());
+      await svc.loadCSV(csvFile());
+
+      let status!: HistoryStatus;
+      svc.history$.subscribe(s => (status = s)).unsubscribe();
+      expect(status.undoLabel).toBe('Datei ersetzt');
+    });
+  });
 });

--- a/src/app/preprocessing-wizard/services/preprocessing.service.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.ts
@@ -3,6 +3,7 @@ import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import {
   PreprocessingState,
   ProcessingProgress,
+  HistoryStatus,
   DEFAULT_CLEANING_CONFIG,
   DEFAULT_PROJECTION_CONFIG,
 } from '../models/preprocessing-state';
@@ -19,6 +20,31 @@ import {
 import { DataProcessorService } from '../../services/data-processor';
 import { DataLoaderService } from '../../services/data-loader.service';
 
+/**
+ * A4 – Undo/Redo. The subset of PreprocessingState that undo restores. Transient
+ * UI fields (currentStep, isProcessing, error, processedDataset, …) are left out
+ * so undoing a data-config change never yanks the user to another step or discards
+ * an in-flight processing run.
+ */
+interface HistorySnapshot {
+  rawFileName: string | null;
+  dataProfile: DataProfile | null;
+  columnConfigs: Map<string, ColumnConfig>;
+  cleaningConfig: CleaningConfig;
+  projectionConfig: ProjectionConfig;
+  datasetName: string;
+  timestamp: string;
+  glyphFeatures: string[];
+  tooltipFeatures: string[];
+  colorScaleMode: 'continuous' | 'categorical';
+  colorScaleId: number;
+}
+
+interface HistoryEntry {
+  label: string; // human-readable description of the action this snapshot precedes
+  snapshot: HistorySnapshot;
+}
+
 @Injectable({
   providedIn: 'root',
 })
@@ -32,6 +58,27 @@ export class PreprocessingService {
   // A6: pending scroll anchor id set by the review step's deep-links. The target
   // step component consumes it once after it renders and scrolls into view.
   private scrollTargetSubject = new BehaviorSubject<string | null>(null);
+
+  // ── A4: Undo/Redo history ────────────────────────────────────────────────
+  // Full state-snapshot stack over the undoable portion of the preprocessing
+  // state. Each completed, state-changing action pushes a snapshot before it
+  // runs; undo()/redo() move snapshots between the two stacks and reinstall them.
+  private undoStack: HistoryEntry[] = [];
+  private redoStack: HistoryEntry[] = [];
+  private readonly MAX_HISTORY = 50;
+
+  private historySubject = new BehaviorSubject<HistoryStatus>({
+    canUndo: false,
+    canRedo: false,
+    undoLabel: null,
+    redoLabel: null,
+  });
+  public history$ = this.historySubject.asObservable();
+
+  // Emitted after undo()/redo() reinstall a snapshot so the shell can refresh the
+  // currently rendered step (steps read state once in ngOnInit and cache locally).
+  private stateRestoredSubject = new Subject<void>();
+  public stateRestored$ = this.stateRestoredSubject.asObservable();
 
   constructor(
     private dataProcessor: DataProcessorService,
@@ -154,6 +201,9 @@ export class PreprocessingService {
       const datasetName = this.getUniqueDatasetName(baseName);
       const timestamp = new Date().toISOString().split('T')[0].replace(/-/g, '');
 
+      // A4: snapshot the prior data before it is replaced, so a re-upload is undoable.
+      this.pushHistory(this.currentState.dataProfile !== null ? 'Datei ersetzt' : 'Datei geladen');
+
       this.updateState({
         dataProfile: profile,
         rawFileName: fileName,
@@ -220,6 +270,14 @@ export class PreprocessingService {
 
   // Column configuration
   public updateColumnConfig(columnName: string, updates: Partial<ColumnConfig>): void {
+    this.pushHistory('Spalteneinstellung geändert');
+    this.applyColumnConfig(columnName, updates);
+  }
+
+  // Applies a column-config change without touching the undo history. Used both by
+  // the public updateColumnConfig (which pushes first) and by other actions that
+  // manage their own history entry, so a single action never records twice.
+  private applyColumnConfig(columnName: string, updates: Partial<ColumnConfig>): void {
     const configs = this.currentState.columnConfigs;
     const existing = configs.get(columnName);
 
@@ -326,7 +384,8 @@ export class PreprocessingService {
   public toggleColumnEnabled(columnName: string): void {
     const config = this.currentState.columnConfigs.get(columnName);
     if (config) {
-      this.updateColumnConfig(columnName, { enabled: !config.enabled });
+      this.pushHistory(config.enabled ? 'Spalte abgewählt' : 'Spalte ausgewählt');
+      this.applyColumnConfig(columnName, { enabled: !config.enabled });
     }
   }
 
@@ -335,6 +394,7 @@ export class PreprocessingService {
    * Step 2 range-select (shift-click) and "select all filtered".
    */
   public setColumnsEnabled(columnNames: string[], enabled: boolean): void {
+    this.pushHistory('Spaltenauswahl geändert');
     const configs = this.currentState.columnConfigs;
     columnNames.forEach(name => {
       const config = configs.get(name);
@@ -347,6 +407,7 @@ export class PreprocessingService {
   }
 
   public selectAllColumns(): void {
+    this.pushHistory('Alle Spalten ausgewählt');
     const configs = this.currentState.columnConfigs;
     configs.forEach(config => (config.enabled = true));
     this.updateState({ columnConfigs: new Map(configs) });
@@ -354,6 +415,7 @@ export class PreprocessingService {
   }
 
   public deselectAllColumns(): void {
+    this.pushHistory('Alle Spalten abgewählt');
     const configs = this.currentState.columnConfigs;
     configs.forEach(config => {
       if (config.originalType !== DataType.ID) {
@@ -366,6 +428,7 @@ export class PreprocessingService {
 
   // Cleaning configuration
   public updateCleaningConfig(updates: Partial<CleaningConfig>): void {
+    this.pushHistory('Bereinigung geändert');
     this.updateState({
       cleaningConfig: { ...this.currentState.cleaningConfig, ...updates },
     });
@@ -374,6 +437,7 @@ export class PreprocessingService {
 
   // Projection configuration
   public updateProjectionConfig(updates: Partial<ProjectionConfig>): void {
+    this.pushHistory('Projektionsparameter geändert');
     this.updateState({
       projectionConfig: { ...this.currentState.projectionConfig, ...updates },
     });
@@ -547,7 +611,111 @@ export class PreprocessingService {
 
   public resetState(): void {
     this.stateSubject.next(this.getInitialState());
+    this.undoStack = [];
+    this.redoStack = [];
+    this.emitHistoryStatus();
     this.clearStateFromStorage();
+  }
+
+  // ── A4: Undo/Redo history ────────────────────────────────────────────────
+
+  /**
+   * Record a snapshot of the current state before a state-changing action runs.
+   * `label` describes the action (e.g. "Smart Defaults angewendet") and drives the
+   * toolbar tooltip. Pushing a new action clears the redo stack, as usual.
+   * Granularity is per completed action (one call per action), never per keystroke.
+   */
+  public pushHistory(label: string): void {
+    this.undoStack.push({ label, snapshot: this.captureSnapshot() });
+    if (this.undoStack.length > this.MAX_HISTORY) {
+      this.undoStack.shift();
+    }
+    this.redoStack = [];
+    this.emitHistoryStatus();
+  }
+
+  public get canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  public get canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  /** Revert the most recent action; returns its label, or null if nothing to undo. */
+  public undo(): string | null {
+    const entry = this.undoStack.pop();
+    if (!entry) return null;
+
+    // Preserve the current state on the redo stack under the same label so redo
+    // can re-apply the reverted action.
+    this.redoStack.push({ label: entry.label, snapshot: this.captureSnapshot() });
+    this.restoreSnapshot(entry.snapshot);
+    this.emitHistoryStatus();
+    this.stateRestoredSubject.next();
+    this.saveStateToStorage();
+    return entry.label;
+  }
+
+  /** Re-apply the most recently undone action; returns its label, or null. */
+  public redo(): string | null {
+    const entry = this.redoStack.pop();
+    if (!entry) return null;
+
+    this.undoStack.push({ label: entry.label, snapshot: this.captureSnapshot() });
+    this.restoreSnapshot(entry.snapshot);
+    this.emitHistoryStatus();
+    this.stateRestoredSubject.next();
+    this.saveStateToStorage();
+    return entry.label;
+  }
+
+  private emitHistoryStatus(): void {
+    this.historySubject.next({
+      canUndo: this.undoStack.length > 0,
+      canRedo: this.redoStack.length > 0,
+      undoLabel: this.undoStack.length > 0 ? this.undoStack[this.undoStack.length - 1].label : null,
+      redoLabel: this.redoStack.length > 0 ? this.redoStack[this.redoStack.length - 1].label : null,
+    });
+  }
+
+  /** Deep-copy the undoable slice of state so later in-place edits cannot mutate it. */
+  private captureSnapshot(): HistorySnapshot {
+    const s = this.currentState;
+    return {
+      rawFileName: s.rawFileName,
+      dataProfile: s.dataProfile, // replaced wholesale on re-upload; reference is safe
+      columnConfigs: this.cloneColumnConfigs(s.columnConfigs),
+      cleaningConfig: { ...s.cleaningConfig },
+      projectionConfig: { ...s.projectionConfig },
+      datasetName: s.datasetName,
+      timestamp: s.timestamp,
+      glyphFeatures: [...s.glyphFeatures],
+      tooltipFeatures: [...s.tooltipFeatures],
+      colorScaleMode: s.colorScaleMode,
+      colorScaleId: s.colorScaleId,
+    };
+  }
+
+  /** Install a snapshot, deep-copying again so the stored entry stays pristine. */
+  private restoreSnapshot(snap: HistorySnapshot): void {
+    this.updateState({
+      rawFileName: snap.rawFileName,
+      dataProfile: snap.dataProfile,
+      columnConfigs: this.cloneColumnConfigs(snap.columnConfigs),
+      cleaningConfig: { ...snap.cleaningConfig },
+      projectionConfig: { ...snap.projectionConfig },
+      datasetName: snap.datasetName,
+      timestamp: snap.timestamp,
+      glyphFeatures: [...snap.glyphFeatures],
+      tooltipFeatures: [...snap.tooltipFeatures],
+      colorScaleMode: snap.colorScaleMode,
+      colorScaleId: snap.colorScaleId,
+    });
+  }
+
+  private cloneColumnConfigs(configs: Map<string, ColumnConfig>): Map<string, ColumnConfig> {
+    return new Map(Array.from(configs.entries()).map(([name, config]) => [name, { ...config }]));
   }
 
   // Persistence

--- a/src/app/preprocessing-wizard/services/preprocessing.service.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.ts
@@ -396,7 +396,11 @@ export class PreprocessingService {
     if (features.length < 3 || features.length > 12) {
       throw new Error('3-12 glyph features required');
     }
-    this.updateState({ glyphFeatures: features });
+    // Store a copy, never the caller's array. Step 4 edits its local selection
+    // array in place (splice/push); if we kept that reference, later in-place edits
+    // would silently mutate the service state and corrupt undo snapshots taken
+    // before the next pushHistory.
+    this.updateState({ glyphFeatures: [...features] });
     this.saveStateToStorage();
   }
 

--- a/src/app/preprocessing-wizard/services/preprocessing.service.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.ts
@@ -45,6 +45,57 @@ interface HistoryEntry {
   snapshot: HistorySnapshot;
 }
 
+/**
+ * A4: result of an undo()/redo() call. Beyond the action label it names the single
+ * setting that changed (settingLabel) and where it lives (step index + scroll anchor),
+ * so the shell can show a precise toast and offer a "jump to change" deep-link.
+ */
+export interface UndoRedoInfo {
+  actionLabel: string; // original history label of the reverted/re-applied action
+  settingLabel: string; // human name of the changed setting (e.g. "Encoding")
+  step: number | null; // wizard step index (0–4) that holds the setting, or null
+  anchorId: string | null; // scroll anchor id inside that step, or null
+}
+
+/**
+ * A4: maps a diff key (top-level snapshot key or `columnConfigs.<field>`) to a
+ * human-readable setting name plus the step index and scroll anchor where the
+ * setting is edited. Step indices are 0-based (0=Upload, 1=Spaltenauswahl,
+ * 2=Datenkonfiguration, 3=Visualisierung, 4=Review). Anchors mirror the ids used
+ * by the review step's deep-links (wizard-anchor-*).
+ */
+interface SettingMeta {
+  label: string;
+  step: number | null;
+  anchorId: string | null;
+}
+
+const SETTING_META: Record<string, SettingMeta> = {
+  // Step 2 – Spaltenauswahl
+  'columnConfigs.enabled': { label: 'Spaltenauswahl', step: 1, anchorId: 'wizard-anchor-columns' },
+  // Step 3 – Datenkonfiguration (per-column features + cleaning)
+  'columnConfigs.encodingMethod': { label: 'Encoding', step: 2, anchorId: 'wizard-anchor-features' },
+  'columnConfigs.scalingMethod': { label: 'Skalierung', step: 2, anchorId: 'wizard-anchor-features' },
+  'columnConfigs.targetType': { label: 'Datentyp', step: 2, anchorId: 'wizard-anchor-features' },
+  'columnConfigs.missingValueStrategy': { label: 'Fehlende Werte', step: 2, anchorId: 'wizard-anchor-features' },
+  'columnConfigs.missingValueFillValue': { label: 'Fehlende Werte', step: 2, anchorId: 'wizard-anchor-features' },
+  'columnConfigs.outlierMethod': { label: 'Ausreißerbehandlung', step: 2, anchorId: 'wizard-anchor-features' },
+  'columnConfigs.outlierStrategy': { label: 'Ausreißerbehandlung', step: 2, anchorId: 'wizard-anchor-features' },
+  cleaningConfig: { label: 'Datenbereinigung', step: 2, anchorId: 'wizard-anchor-cleaning' },
+  // Step 4 – Visualisierung (color / glyph / projection live here)
+  'columnConfigs.includeInProjection': { label: 'Projektionsspalten', step: 3, anchorId: 'wizard-anchor-projection-columns' },
+  'columnConfigs.isColorFeature': { label: 'Farbattribut', step: 3, anchorId: 'wizard-anchor-color' },
+  isColorFeature: { label: 'Farbattribut', step: 3, anchorId: 'wizard-anchor-color' },
+  colorScaleId: { label: 'Farbskala', step: 3, anchorId: 'wizard-anchor-color' },
+  colorScaleMode: { label: 'Farbmodus', step: 3, anchorId: 'wizard-anchor-color' },
+  glyphFeatures: { label: 'Glyph-Merkmale', step: 3, anchorId: 'wizard-anchor-glyph' },
+  tooltipFeatures: { label: 'Tooltip-Merkmale', step: 3, anchorId: 'wizard-anchor-glyph' },
+  projectionConfig: { label: 'Projektionsparameter', step: 3, anchorId: 'wizard-anchor-methods' },
+  // Step 1 – Upload
+  rawFileName: { label: 'Datei', step: 0, anchorId: null },
+  datasetName: { label: 'Datensatzname', step: 0, anchorId: null },
+};
+
 @Injectable({
   providedIn: 'root',
 })
@@ -386,6 +437,7 @@ export class PreprocessingService {
     if (config) {
       this.pushHistory(config.enabled ? 'Spalte abgewählt' : 'Spalte ausgewählt');
       this.applyColumnConfig(columnName, { enabled: !config.enabled });
+      this.validateDependentReferences();
     }
   }
 
@@ -403,6 +455,7 @@ export class PreprocessingService {
       }
     });
     this.updateState({ columnConfigs: new Map(configs) });
+    this.validateDependentReferences();
     this.saveStateToStorage();
   }
 
@@ -411,6 +464,7 @@ export class PreprocessingService {
     const configs = this.currentState.columnConfigs;
     configs.forEach(config => (config.enabled = true));
     this.updateState({ columnConfigs: new Map(configs) });
+    this.validateDependentReferences();
     this.saveStateToStorage();
   }
 
@@ -423,6 +477,61 @@ export class PreprocessingService {
       }
     });
     this.updateState({ columnConfigs: new Map(configs) });
+    this.validateDependentReferences();
+    this.saveStateToStorage();
+  }
+
+  /**
+   * A4/cross-field: after any change to which columns are enabled, remove references
+   * that would otherwise dangle on now-disabled columns. Concretely: a disabled
+   * column can no longer be the color feature, and glyph/tooltip mappings drop
+   * features whose underlying column is disabled. If the color feature was cleared,
+   * the color scale falls back to the numeric default so the review/step 4 UI does
+   * not keep showing a scale for a column that is gone.
+   *
+   * Runs after the enable change (and after pushHistory captured the pre-change
+   * snapshot), so a single undo reverts both the enable change and this cleanup as
+   * one atomic action, while the redo snapshot holds the already-cleaned state.
+   */
+  private validateDependentReferences(): void {
+    const configs = this.currentState.columnConfigs;
+    let changed = false;
+    let colorFeatureCleared = false;
+
+    // Drop color-feature flag from disabled columns.
+    configs.forEach(config => {
+      if (!config.enabled && config.isColorFeature) {
+        config.isColorFeature = false;
+        colorFeatureCleared = true;
+        changed = true;
+      }
+    });
+
+    // Glyph/tooltip mappings may only reference features of still-enabled columns.
+    // predictEncodedFeatureNames() already restricts itself to enabled columns and
+    // handles one-hot expansion, so it is the source of truth for valid names.
+    const validFeatures = new Set(this.predictEncodedFeatureNames());
+    const glyphFeatures = this.currentState.glyphFeatures.filter(f => validFeatures.has(f));
+    const tooltipFeatures = this.currentState.tooltipFeatures.filter(f => validFeatures.has(f));
+    const glyphChanged = glyphFeatures.length !== this.currentState.glyphFeatures.length;
+    const tooltipChanged = tooltipFeatures.length !== this.currentState.tooltipFeatures.length;
+
+    if (!changed && !glyphChanged && !tooltipChanged) {
+      return;
+    }
+
+    const updates: Partial<PreprocessingState> = {
+      columnConfigs: new Map(configs),
+    };
+    if (glyphChanged) updates.glyphFeatures = glyphFeatures;
+    if (tooltipChanged) updates.tooltipFeatures = tooltipFeatures;
+    // When the color feature is gone, reset the color scale to the numeric default.
+    if (colorFeatureCleared) {
+      updates.colorScaleId = 0;
+      updates.colorScaleMode = 'continuous';
+    }
+
+    this.updateState(updates);
     this.saveStateToStorage();
   }
 
@@ -642,32 +751,107 @@ export class PreprocessingService {
     return this.redoStack.length > 0;
   }
 
-  /** Revert the most recent action; returns its label, or null if nothing to undo. */
-  public undo(): string | null {
+  /** Revert the most recent action; returns info about the change, or null. */
+  public undo(): UndoRedoInfo | null {
     const entry = this.undoStack.pop();
     if (!entry) return null;
 
+    // Diff the current (about-to-be-reverted) state against the target snapshot to
+    // name the setting that changes, before we replace the state.
+    const before = this.captureSnapshot();
+    const info = this.describeDiff(entry.label, before, entry.snapshot);
+
     // Preserve the current state on the redo stack under the same label so redo
     // can re-apply the reverted action.
-    this.redoStack.push({ label: entry.label, snapshot: this.captureSnapshot() });
+    this.redoStack.push({ label: entry.label, snapshot: before });
     this.restoreSnapshot(entry.snapshot);
     this.emitHistoryStatus();
     this.stateRestoredSubject.next();
     this.saveStateToStorage();
-    return entry.label;
+    return info;
   }
 
-  /** Re-apply the most recently undone action; returns its label, or null. */
-  public redo(): string | null {
+  /** Re-apply the most recently undone action; returns info about the change, or null. */
+  public redo(): UndoRedoInfo | null {
     const entry = this.redoStack.pop();
     if (!entry) return null;
 
-    this.undoStack.push({ label: entry.label, snapshot: this.captureSnapshot() });
+    const before = this.captureSnapshot();
+    const info = this.describeDiff(entry.label, before, entry.snapshot);
+
+    this.undoStack.push({ label: entry.label, snapshot: before });
     this.restoreSnapshot(entry.snapshot);
     this.emitHistoryStatus();
     this.stateRestoredSubject.next();
     this.saveStateToStorage();
-    return entry.label;
+    return info;
+  }
+
+  /**
+   * Build the toast/deep-link descriptor for an undo/redo by diffing the state
+   * before against the snapshot being installed and looking up the changed key in
+   * SETTING_META. Falls back to the raw action label when nothing maps cleanly.
+   */
+  private describeDiff(actionLabel: string, before: HistorySnapshot, after: HistorySnapshot): UndoRedoInfo {
+    const key = this.diffSnapshots(before, after);
+    const meta = key ? SETTING_META[key] : undefined;
+    return {
+      actionLabel,
+      settingLabel: meta?.label ?? actionLabel,
+      step: meta?.step ?? null,
+      anchorId: meta?.anchorId ?? null,
+    };
+  }
+
+  /**
+   * Return the diff key for the first differing field between two snapshots, or
+   * null if they are equal. Keys are either a top-level snapshot key or, for
+   * column configs, `columnConfigs.<field>`. Order roughly follows the wizard steps.
+   */
+  private diffSnapshots(a: HistorySnapshot, b: HistorySnapshot): string | null {
+    if (a.rawFileName !== b.rawFileName) return 'rawFileName';
+    if (a.datasetName !== b.datasetName) return 'datasetName';
+
+    const columnKey = this.diffColumnConfigs(a.columnConfigs, b.columnConfigs);
+    if (columnKey) return columnKey;
+
+    if (JSON.stringify(a.cleaningConfig) !== JSON.stringify(b.cleaningConfig)) return 'cleaningConfig';
+    if (JSON.stringify(a.projectionConfig) !== JSON.stringify(b.projectionConfig)) return 'projectionConfig';
+    if (!this.arraysEqual(a.glyphFeatures, b.glyphFeatures)) return 'glyphFeatures';
+    if (!this.arraysEqual(a.tooltipFeatures, b.tooltipFeatures)) return 'tooltipFeatures';
+    if (a.colorScaleMode !== b.colorScaleMode) return 'colorScaleMode';
+    if (a.colorScaleId !== b.colorScaleId) return 'colorScaleId';
+    return null;
+  }
+
+  /** Per-field diff over the column-config maps; returns `columnConfigs.<field>`. */
+  private diffColumnConfigs(a: Map<string, ColumnConfig>, b: Map<string, ColumnConfig>): string | null {
+    const fields: (keyof ColumnConfig)[] = [
+      'enabled',
+      'isColorFeature',
+      'targetType',
+      'encodingMethod',
+      'scalingMethod',
+      'includeInProjection',
+      'missingValueStrategy',
+      'missingValueFillValue',
+      'outlierMethod',
+      'outlierStrategy',
+    ];
+    const names = new Set([...a.keys(), ...b.keys()]);
+    for (const name of names) {
+      const ca = a.get(name);
+      const cb = b.get(name);
+      if (!ca || !cb) return 'columnConfigs.enabled'; // column added/removed ~ selection change
+      for (const field of fields) {
+        if (ca[field] !== cb[field]) return `columnConfigs.${field}`;
+      }
+    }
+    return null;
+  }
+
+  private arraysEqual(a: string[], b: string[]): boolean {
+    return a.length === b.length && a.every((v, i) => v === b[i]);
   }
 
   private emitHistoryStatus(): void {

--- a/src/app/preprocessing-wizard/steps/step1-upload/step1-upload.component.ts
+++ b/src/app/preprocessing-wizard/steps/step1-upload/step1-upload.component.ts
@@ -8,6 +8,7 @@ import { DataProfile } from '../../models/column-statistics';
 import { HelpTooltipComponent } from '../../shared/help-tooltip/help-tooltip.component';
 import { STEP_INFO } from '../../shared/constants/step-info';
 import { WizardStep, WIZARD_STEP } from '../../shared/wizard-step';
+import { ToastService } from '../../../services/toast.service';
 
 @Component({
   selector: 'app-step1-upload',
@@ -30,7 +31,10 @@ export class Step1UploadComponent implements OnInit, OnDestroy, WizardStep {
   // Expose step info to template
   readonly stepInfo = STEP_INFO[0]; // Step 1 (index 0)
 
-  constructor(private preprocessingService: PreprocessingService) {}
+  constructor(
+    private preprocessingService: PreprocessingService,
+    private toastService: ToastService
+  ) {}
 
   ngOnInit(): void {
     // Subscribe to state changes to react to reset
@@ -103,10 +107,17 @@ export class Step1UploadComponent implements OnInit, OnDestroy, WizardStep {
     this.isLoading = true;
     this.error = null;
 
+    // A4: if a dataset was already loaded, this upload replaces it (and its column
+    // config). loadCSV snapshots the prior state, so we offer a one-click undo.
+    const wasReplacement = this.preprocessingService.currentState.dataProfile !== null;
+
     try {
       this.profile = await this.preprocessingService.loadCSV(file);
       // Don't emit here - let user review the data first
       // User will click "Continue to Column Selection" button to emit and proceed
+      if (wasReplacement) {
+        this.toastService.showUndo('Datei ersetzt', () => this.preprocessingService.undo());
+      }
     } catch (err: unknown) {
       this.error = err instanceof Error ? err.message : 'Failed to load data file';
       this.profile = null;

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.html
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.html
@@ -6,6 +6,9 @@
         {{ error }}
       </div>
     } @else {
+      <!-- A4/A6: deep-link scroll target for per-column feature settings
+           (encoding, scaling, data type, missing values, outliers). -->
+      <span id="wizard-anchor-features" class="scroll-anchor"></span>
       <!-- Master rail + recessed detail well -->
       <div class="config-shell">
         <!-- LEFT RAIL: dataset columns -->
@@ -454,6 +457,8 @@
         </div>
       </div>
 
+      <!-- A4/A6: deep-link scroll target for data-cleaning settings. -->
+      <span id="wizard-anchor-cleaning" class="scroll-anchor"></span>
       <!-- Duplicate Rows Section (only shown when duplicates exist) -->
       @if (duplicateCount > 0) {
         <div class="duplicates-section">

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.scss
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.scss
@@ -2,6 +2,15 @@
 @use '../../../../styles/variables' as v;
 @use '../../../../styles/mixins' as m;
 
+// A4/A6: invisible scroll anchor used by deep-links (undo/redo "Änderung anzeigen"
+// and review edit-links) so a target setting scrolls into view without a sticky
+// header covering it.
+.scroll-anchor {
+  display: block;
+  height: 0;
+  scroll-margin-top: 12px;
+}
+
 .step3-configure-data-features {
   display: flex;
   flex-direction: column;

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.ts
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, forwardRef, ViewChild, ElementRef, HostListener } from '@angular/core';
+import { Component, OnInit, AfterViewInit, forwardRef, ViewChild, ElementRef, HostListener } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { PreprocessingService } from '../../services/preprocessing.service';
 import { WizardStep, WIZARD_STEP } from '../../shared/wizard-step';
@@ -36,7 +36,7 @@ interface ColumnConfigState {
   styleUrl: './step3-configure-data-features.component.scss',
   providers: [{ provide: WIZARD_STEP, useExisting: forwardRef(() => Step3ConfigureDataFeaturesComponent) }],
 })
-export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
+export class Step3ConfigureDataFeaturesComponent implements OnInit, AfterViewInit, WizardStep {
   readonly primaryLabel = 'Continue to Visualization Settings';
   readonly disabledHint = '';
 
@@ -138,6 +138,18 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
   ngOnInit(): void {
     this.loadData();
     this.detectDuplicates();
+  }
+
+  // A4/A6: scroll the requested setting into view when arriving via a deep-link
+  // (undo/redo "Änderung anzeigen" or a review edit-link). The delay lets the
+  // shell's scroll-to-top run first so it does not override this.
+  ngAfterViewInit(): void {
+    const target = this.preprocessingService.consumeScrollTarget();
+    if (target) {
+      setTimeout(() => {
+        document.getElementById(target)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }, 120);
+    }
   }
 
   private loadData(): void {

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.ts
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.ts
@@ -18,6 +18,7 @@ import { HelpTooltipComponent } from '../../shared/help-tooltip/help-tooltip.com
 import { HELP_TEXT } from '../../shared/constants/help-text';
 import { STEP_INFO } from '../../shared/constants/step-info';
 import { DataPreviewTableComponent } from '../../shared/data-preview-table/data-preview-table.component';
+import { ToastService } from '../../../services/toast.service';
 
 interface ColumnConfigState {
   column: ColumnStatistics;
@@ -127,7 +128,10 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
   readonly HELP_TEXT = HELP_TEXT;
   readonly stepInfo = STEP_INFO[2]; // Step 3 (index 2)
 
-  constructor(public preprocessingService: PreprocessingService) {
+  constructor(
+    public preprocessingService: PreprocessingService,
+    private toastService: ToastService
+  ) {
     this.cleaningConfig = this.preprocessingService.currentState.cleaningConfig;
   }
 
@@ -268,10 +272,29 @@ export class Step3ConfigureDataFeaturesComponent implements OnInit, WizardStep {
   }
 
   clearFilters(): void {
+    // A4: filters are view-only state (not part of preprocessing-state), so this
+    // action is made reversible via a toast whose undo restores the local values,
+    // rather than through the global snapshot stack.
+    const previous = {
+      filterText: this.filterText,
+      filterType: this.filterType,
+      showIssuesOnly: this.showIssuesOnly,
+    };
+    const hadActiveFilter = !!this.filterText || this.filterType !== 'all' || this.showIssuesOnly;
+
     this.filterText = '';
     this.filterType = 'all';
     this.showIssuesOnly = false;
     this.applyFilters();
+
+    if (hadActiveFilter) {
+      this.toastService.showUndo('Filter zurückgesetzt', () => {
+        this.filterText = previous.filterText;
+        this.filterType = previous.filterType;
+        this.showIssuesOnly = previous.showIssuesOnly;
+        this.applyFilters();
+      });
+    }
   }
 
   // ============================================================================

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -39,7 +39,7 @@
           </h3>
           <button
             class="btn-suggestion-compact"
-            (click)="applySuggestedFeatures()"
+            (click)="applySuggestedFeaturesByUser()"
             [disabled]="suggestedFeatures.length === 0 || !suggestionsWouldChange()"
           >
             <span class="material-icons">auto_awesome</span>

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.spec.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.spec.ts
@@ -1,0 +1,228 @@
+import { Step4VisualizationSettingsComponent } from './step4-visualization-settings.component';
+import { PreprocessingService } from '../../services/preprocessing.service';
+import { PreprocessingState } from '../../models/preprocessing-state';
+import { ColumnConfig } from '../../models/column-config';
+import {
+  DataType,
+  EncodingMethod,
+  ScalingMethod,
+  MissingValueStrategy,
+  OutlierMethod,
+  OutlierStrategy,
+} from '../../models/data-type.enum';
+import { ToastService } from '../../../services/toast.service';
+
+/**
+ * A4 – Step 4 glyph-feature editing vs. the undo history.
+ *
+ * Regression coverage for the reported flaky behaviour: deselecting every glyph
+ * feature one by one and then pressing undo once brought several features back
+ * instead of exactly one.
+ *
+ * Root cause: removeGlyphFeature() spliced the component's local
+ * selectedGlyphFeatures array first and only then called saveGlyphFeatures(),
+ * whose guard skips both the history push AND service.setGlyphFeatures() whenever
+ * the count leaves the valid 3–12 range. Removals below the minimum therefore
+ * silently desynced the local array from the service state and were never
+ * recorded, so a single undo no longer mapped to a single user action.
+ *
+ * These tests pin the invariants a correct implementation must keep:
+ *  - the local selection never drops below MIN_GLYPH_FEATURES,
+ *  - the local selection and the service state stay in sync after every removal,
+ *  - each persisted removal is exactly one undo entry.
+ */
+describe('Step4VisualizationSettingsComponent – glyph feature history', () => {
+  let component: Step4VisualizationSettingsComponent;
+  let service: PreprocessingService;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  const dataProcessorStub = {} as unknown as ConstructorParameters<typeof PreprocessingService>[0];
+  const dataLoaderStub = {
+    getDataSetNames: () => [] as string[],
+  } as unknown as ConstructorParameters<typeof PreprocessingService>[1];
+
+  const FIVE = ['a', 'b', 'c', 'd', 'e'];
+
+  /** Put the component and the service into a synced "5 glyph features" state. */
+  function startWithFiveFeatures(): void {
+    service.setGlyphFeatures([...FIVE]);
+    component.selectedGlyphFeatures = [...FIVE];
+    // Mark loading as finished so glyph writes are treated as genuine user actions.
+    (component as unknown as { historyReady: boolean }).historyReady = true;
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    service = new PreprocessingService(dataProcessorStub, dataLoaderStub);
+    toast = jasmine.createSpyObj<ToastService>('ToastService', ['warning', 'success', 'showUndo', 'info', 'error']);
+    component = new Step4VisualizationSettingsComponent(service, toast);
+  });
+
+  afterEach(() => localStorage.clear());
+
+  it('never lets the selection drop below the minimum when removing repeatedly', () => {
+    startWithFiveFeatures();
+
+    // Try to remove all five, one by one (always removing the first chip).
+    for (let i = 0; i < 5; i++) {
+      component.removeGlyphFeature(0);
+    }
+
+    expect(component.selectedGlyphFeatures.length).toBe(component.MIN_GLYPH_FEATURES);
+  });
+
+  it('keeps the local selection and the service state in sync after each removal', () => {
+    startWithFiveFeatures();
+
+    for (let i = 0; i < 5; i++) {
+      component.removeGlyphFeature(0);
+      expect(service.currentState.glyphFeatures)
+        .withContext(`after ${i + 1} removal(s)`)
+        .toEqual(component.selectedGlyphFeatures);
+    }
+  });
+
+  it('records exactly one undo entry per persisted removal, so a single undo reverts one step', () => {
+    startWithFiveFeatures();
+
+    // Two valid removals: 5 -> 4 -> 3.
+    component.removeGlyphFeature(0);
+    component.removeGlyphFeature(0);
+    expect(service.currentState.glyphFeatures.length).toBe(3);
+
+    // A single undo restores exactly one removed feature (3 -> 4), not several.
+    service.undo();
+    expect(service.currentState.glyphFeatures.length).toBe(4);
+  });
+
+  it('does not push a history entry or change state when removal is blocked at the minimum', () => {
+    service.setGlyphFeatures(['a', 'b', 'c']);
+    component.selectedGlyphFeatures = ['a', 'b', 'c'];
+    (component as unknown as { historyReady: boolean }).historyReady = true;
+    expect(service.canUndo).toBeFalse();
+
+    component.removeGlyphFeature(0);
+
+    expect(component.selectedGlyphFeatures).toEqual(['a', 'b', 'c']);
+    expect(service.currentState.glyphFeatures).toEqual(['a', 'b', 'c']);
+    expect(service.canUndo).toBeFalse();
+  });
+
+  it('adds a glyph feature back as one undoable action', () => {
+    service.setGlyphFeatures(['a', 'b', 'c']);
+    component.selectedGlyphFeatures = ['a', 'b', 'c'];
+    (component as unknown as { historyReady: boolean }).historyReady = true;
+
+    component.addGlyphFeature('d');
+    expect(service.currentState.glyphFeatures).toEqual(['a', 'b', 'c', 'd']);
+
+    service.undo();
+    expect(service.currentState.glyphFeatures).toEqual(['a', 'b', 'c']);
+  });
+});
+
+/**
+ * A4 – Step 4 colour selection vs. the undo history.
+ *
+ * Colour attribute and colour scale were the one Step-4 setting the undo stack did
+ * not record, so pressing undo after changing a colour silently reverted an earlier
+ * action instead. These tests pin that a colour change is exactly one undoable
+ * action, while the default colour assigned during ngOnInit is not.
+ */
+describe('Step4VisualizationSettingsComponent – colour feature history', () => {
+  let component: Step4VisualizationSettingsComponent;
+  let service: PreprocessingService;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  const dataProcessorStub = {} as unknown as ConstructorParameters<typeof PreprocessingService>[0];
+  const dataLoaderStub = {
+    getDataSetNames: () => [] as string[],
+  } as unknown as ConstructorParameters<typeof PreprocessingService>[1];
+
+  function makeConfig(name: string, isColorFeature: boolean): ColumnConfig {
+    return {
+      name,
+      originalType: DataType.Numeric,
+      targetType: DataType.Numeric,
+      encodingMethod: EncodingMethod.Normalize,
+      scalingMethod: ScalingMethod.MinMax,
+      includeInProjection: true,
+      isColorFeature,
+      missingValueStrategy: MissingValueStrategy.Keep,
+      outlierMethod: OutlierMethod.IQR_1_5,
+      outlierStrategy: OutlierStrategy.Keep,
+      enabled: true,
+      hasIssues: false,
+    };
+  }
+
+  /** Two enabled numeric columns; "red" is the initial colour feature, scale 0. */
+  function seedColourState(): void {
+    const configs = new Map<string, ColumnConfig>([
+      ['red', makeConfig('red', true)],
+      ['blue', makeConfig('blue', false)],
+    ]);
+    (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({
+      columnConfigs: configs,
+      colorScaleId: 0,
+      colorScaleMode: 'continuous',
+    });
+    component.colorFeature = 'red';
+    component.selectedColorScaleId = 0;
+  }
+
+  function ready(): void {
+    (component as unknown as { historyReady: boolean }).historyReady = true;
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    service = new PreprocessingService(dataProcessorStub, dataLoaderStub);
+    toast = jasmine.createSpyObj<ToastService>('ToastService', ['warning', 'success', 'showUndo', 'info', 'error']);
+    component = new Step4VisualizationSettingsComponent(service, toast);
+  });
+
+  afterEach(() => localStorage.clear());
+
+  it('records a colour-feature change as one undoable action', () => {
+    seedColourState();
+    ready();
+
+    component.setColorFeature('blue');
+    expect(service.currentState.columnConfigs.get('blue')!.isColorFeature).toBeTrue();
+    expect(service.currentState.columnConfigs.get('red')!.isColorFeature).toBeFalse();
+    expect(service.canUndo).toBeTrue();
+
+    service.undo();
+    expect(service.currentState.columnConfigs.get('red')!.isColorFeature).toBeTrue();
+    expect(service.currentState.columnConfigs.get('blue')!.isColorFeature).toBeFalse();
+  });
+
+  it('labels a colour-feature undo as Farbattribut on step 4', () => {
+    seedColourState();
+    ready();
+
+    component.setColorFeature('blue');
+    const info = service.undo()!;
+    expect(info.settingLabel).toBe('Farbattribut');
+    expect(info.step).toBe(3);
+  });
+
+  it('records a colour-scale change as one undoable action', () => {
+    seedColourState();
+    ready();
+
+    component.selectColorScale(2);
+    expect(service.currentState.colorScaleId).toBe(2);
+
+    service.undo();
+    expect(service.currentState.colorScaleId).toBe(0);
+  });
+
+  it('does not record colour history before the step has finished loading', () => {
+    seedColourState();
+    // historyReady stays false, mirroring the ngOnInit default assignment.
+    component.setColorFeature('blue');
+    expect(service.canUndo).toBeFalse();
+  });
+});

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.spec.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.spec.ts
@@ -226,3 +226,129 @@ describe('Step4VisualizationSettingsComponent – colour feature history', () =>
     expect(service.canUndo).toBeFalse();
   });
 });
+
+/**
+ * A4 – Step 4 drag & drop, smart suggestions and projection columns vs. undo.
+ *
+ * These paths also mutate the glyph selection or a column config; they must each
+ * be a single undoable action and stay in sync with the service state.
+ */
+describe('Step4VisualizationSettingsComponent – drag/drop, suggestions, projection', () => {
+  let component: Step4VisualizationSettingsComponent;
+  let service: PreprocessingService;
+  let toast: jasmine.SpyObj<ToastService>;
+
+  const dataProcessorStub = {} as unknown as ConstructorParameters<typeof PreprocessingService>[0];
+  const dataLoaderStub = {
+    getDataSetNames: () => [] as string[],
+  } as unknown as ConstructorParameters<typeof PreprocessingService>[1];
+
+  function makeConfig(name: string): ColumnConfig {
+    return {
+      name,
+      originalType: DataType.Numeric,
+      targetType: DataType.Numeric,
+      encodingMethod: EncodingMethod.Normalize,
+      scalingMethod: ScalingMethod.MinMax,
+      includeInProjection: true,
+      isColorFeature: false,
+      missingValueStrategy: MissingValueStrategy.Keep,
+      outlierMethod: OutlierMethod.IQR_1_5,
+      outlierStrategy: OutlierStrategy.Keep,
+      enabled: true,
+      hasIssues: false,
+    };
+  }
+
+  // Minimal DragEvent stand-in: only the members the handlers actually touch.
+  function dragEvent(): DragEvent {
+    return {
+      preventDefault: () => undefined,
+      stopPropagation: () => undefined,
+      dataTransfer: { effectAllowed: '', dropEffect: '', setData: () => undefined, getData: () => '' },
+    } as unknown as DragEvent;
+  }
+
+  function ready(): void {
+    (component as unknown as { historyReady: boolean }).historyReady = true;
+  }
+
+  beforeEach(() => {
+    localStorage.clear();
+    service = new PreprocessingService(dataProcessorStub, dataLoaderStub);
+    toast = jasmine.createSpyObj<ToastService>('ToastService', ['warning', 'success', 'showUndo', 'info', 'error']);
+    component = new Step4VisualizationSettingsComponent(service, toast);
+  });
+
+  afterEach(() => localStorage.clear());
+
+  it('reorders a glyph feature via drag as one undoable action', () => {
+    service.setGlyphFeatures(['a', 'b', 'c', 'd', 'e']);
+    component.selectedGlyphFeatures = ['a', 'b', 'c', 'd', 'e'];
+    ready();
+
+    component.onDragStart(dragEvent(), 'a', 'selected', 0);
+    component.onDropOnSelectedItem(dragEvent(), 2);
+    expect(component.selectedGlyphFeatures).toEqual(['b', 'c', 'a', 'd', 'e']);
+    expect(service.currentState.glyphFeatures).toEqual(['b', 'c', 'a', 'd', 'e']);
+
+    service.undo();
+    expect(service.currentState.glyphFeatures).toEqual(['a', 'b', 'c', 'd', 'e']);
+  });
+
+  it('adds a feature by dropping it into the selected list, undoable', () => {
+    service.setGlyphFeatures(['a', 'b', 'c']);
+    component.selectedGlyphFeatures = ['a', 'b', 'c'];
+    component.availableFeatures = ['a', 'b', 'c', 'd'];
+    ready();
+
+    component.onDragStart(dragEvent(), 'd', 'available', 0);
+    component.onDropInSelected(dragEvent());
+    expect(service.currentState.glyphFeatures).toEqual(['a', 'b', 'c', 'd']);
+
+    service.undo();
+    expect(service.currentState.glyphFeatures).toEqual(['a', 'b', 'c']);
+  });
+
+  it('removes a feature by dropping it onto the available area, undoable', () => {
+    service.setGlyphFeatures(['a', 'b', 'c', 'd']);
+    component.selectedGlyphFeatures = ['a', 'b', 'c', 'd'];
+    ready();
+
+    component.onDragStart(dragEvent(), 'd', 'selected', 3);
+    component.onDropInAvailable(dragEvent());
+    expect(service.currentState.glyphFeatures).toEqual(['a', 'b', 'c']);
+
+    service.undo();
+    expect(service.currentState.glyphFeatures).toEqual(['a', 'b', 'c', 'd']);
+  });
+
+  it('applies recommended features as one undoable action and offers a toast undo', () => {
+    component.suggestedFeatures = ['a', 'b', 'c', 'd', 'e'];
+    component.availableFeatures = ['a', 'b', 'c', 'd', 'e', 'f'];
+    ready();
+
+    component.applySuggestedFeaturesByUser();
+    expect(component.selectedGlyphFeatures).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(service.currentState.glyphFeatures).toEqual(['a', 'b', 'c', 'd', 'e']);
+    expect(toast.showUndo).toHaveBeenCalled();
+
+    service.undo();
+    expect(service.currentState.glyphFeatures).toEqual([]);
+  });
+
+  it('toggles a projection column as one undoable action', () => {
+    const configs = new Map<string, ColumnConfig>([['x', makeConfig('x')]]);
+    (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({ columnConfigs: configs });
+    component.projectionColumns = [
+      { column: { name: 'x' } as never, config: service.currentState.columnConfigs.get('x')! },
+    ] as never;
+
+    component.toggleColumnProjection('x');
+    expect(service.currentState.columnConfigs.get('x')!.includeInProjection).toBeFalse();
+    expect(service.canUndo).toBeTrue();
+
+    service.undo();
+    expect(service.currentState.columnConfigs.get('x')!.includeInProjection).toBeTrue();
+  });
+});

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
@@ -17,6 +17,7 @@ import { STEP_INFO } from '../../shared/constants/step-info';
 import { DataTypeBadgeComponent } from '../../shared/data-type-badge/data-type-badge.component';
 import { COLOR_SCALES, ColorScale, buildGroupedColorScales } from '../../../shared/interfaces/color-scale';
 import { ColorScaleSelectorComponent } from '../../../shared/components/color-scale-selector/color-scale-selector.component';
+import { ToastService } from '../../../services/toast.service';
 
 /** A dataset column paired with its live configuration, used for projection column selection. */
 interface ProjectionColumnState {
@@ -307,7 +308,15 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
   readonly HELP_TEXT = HELP_TEXT;
   readonly stepInfo = STEP_INFO[3]; // Step 4 (index 3)
 
-  constructor(public preprocessingService: PreprocessingService) {}
+  // A4: guards the history push in saveGlyphFeatures so glyph writes during the
+  // initial load (ngOnInit) do not create spurious undo entries. Flipped true once
+  // the step has finished loading.
+  private historyReady = false;
+
+  constructor(
+    public preprocessingService: PreprocessingService,
+    private toastService: ToastService
+  ) {}
 
   // A6: if the review step requested a jump to a specific setting, scroll its
   // anchor into view once this step has rendered. The delay lets the shell's
@@ -368,6 +377,10 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
     if (state.projectionConfig) {
       this.projectionConfig = { ...state.projectionConfig };
     }
+
+    // A4: from here on, glyph-feature writes are genuine user actions and should
+    // be recorded on the undo stack.
+    this.historyReady = true;
   }
 
   // ============================================================================
@@ -517,8 +530,24 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
       this.selectedGlyphFeatures.length >= this.MIN_GLYPH_FEATURES &&
       this.selectedGlyphFeatures.length <= this.MAX_GLYPH_FEATURES
     ) {
+      // A4: every completed glyph edit (add/remove/reorder/apply-suggestions)
+      // funnels through here, so a single history push covers them all. Snapshot
+      // the state before the write so undo restores the previous feature set.
+      if (this.historyReady) {
+        this.preprocessingService.pushHistory('Glyph-Merkmale geändert');
+      }
       this.preprocessingService.setGlyphFeatures(this.selectedGlyphFeatures);
     }
+  }
+
+  /**
+   * A4: user-triggered "apply recommended features" (Smart Defaults). Applies the
+   * suggestions (which records a single history entry via saveGlyphFeatures) and
+   * shows a confirmation toast with a one-click undo.
+   */
+  applySuggestedFeaturesByUser(): void {
+    this.applySuggestedFeatures();
+    this.toastService.showUndo('Empfohlene Merkmale angewendet', () => this.preprocessingService.undo());
   }
 
   // Drag & Drop

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
@@ -388,6 +388,12 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
   // ============================================================================
 
   setColorFeature(columnName: string): void {
+    // A4: record the colour change so undo reverts the colour feature (and any
+    // auto-switched scale) as one action. Guarded by historyReady so the default
+    // colour assigned during ngOnInit does not create a spurious history entry.
+    if (this.historyReady) {
+      this.preprocessingService.pushHistory('Farbattribut geändert');
+    }
     this.colorFeature = columnName;
     this.preprocessingService.setColorFeature(columnName);
     // Sync selected scale ID after service auto-switches on type mismatch
@@ -399,6 +405,10 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
   }
 
   selectColorScale(id: number): void {
+    // A4: same as the colour feature — record so a scale change is undoable.
+    if (this.historyReady) {
+      this.preprocessingService.pushHistory('Farbskala geändert');
+    }
     this.selectedColorScaleId = id;
     this.preprocessingService.setColorScaleId(id);
   }
@@ -480,6 +490,14 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
   }
 
   removeGlyphFeature(index: number): void {
+    // A glyph needs at least MIN_GLYPH_FEATURES rays. Removing below that is not a
+    // persistable state (setGlyphFeatures rejects it), so block it here instead of
+    // letting the local selection drift out of sync with the service and skipping
+    // the history entry — that mismatch is what made undo restore several features.
+    if (this.selectedGlyphFeatures.length <= this.MIN_GLYPH_FEATURES) {
+      this.toastService.warning(`Mindestens ${this.MIN_GLYPH_FEATURES} Glyph-Merkmale erforderlich.`);
+      return;
+    }
     this.selectedGlyphFeatures.splice(index, 1);
     this.saveGlyphFeatures();
     this.regeneratePreviewData();

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.html
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.html
@@ -284,7 +284,7 @@
   @if (processingComplete && !isProcessing) {
     <div class="action-buttons">
       <button class="btn-secondary" (click)="startOver()">
-        <span class="material-icons">refresh</span>
+        <span class="material-icons">delete</span>
         <span>Process Another Dataset</span>
       </button>
 

--- a/src/app/services/toast.service.ts
+++ b/src/app/services/toast.service.ts
@@ -12,10 +12,6 @@ export interface Toast {
   type: 'success' | 'error' | 'info' | 'warning';
   duration?: number;
   action?: ToastAction; // optional inline action button (e.g. "Rückgängig")
-  // Optional category. Toasts sharing a tag never stack: showing a new one with a
-  // given tag removes any currently visible toast that carries the same tag, so
-  // e.g. rapid undo/redo actions replace one another instead of piling up.
-  tag?: string;
 }
 
 @Injectable({
@@ -26,21 +22,16 @@ export class ToastService {
   public toasts$ = this.toastsSubject.asObservable();
   private nextId = 0;
 
-  show(message: string, type: Toast['type'] = 'info', duration = 5000, action?: ToastAction, tag?: string): void {
+  show(message: string, type: Toast['type'] = 'info', duration = 5000, action?: ToastAction): void {
     const toast: Toast = {
       id: this.nextId++,
       message,
       type,
       duration,
       action,
-      tag,
     };
 
-    // Same-tag toasts do not stack: drop any currently visible one first so only
-    // the latest is shown (single-slot behaviour for undo/redo feedback).
-    const currentToasts = tag
-      ? this.toastsSubject.getValue().filter(t => t.tag !== tag)
-      : this.toastsSubject.getValue();
+    const currentToasts = this.toastsSubject.getValue();
     this.toastsSubject.next([...currentToasts, toast]);
 
     // Auto-remove after duration
@@ -57,19 +48,6 @@ export class ToastService {
    */
   showUndo(message: string, undoHandler: () => void, duration = 6000): void {
     this.show(message, 'info', duration, { label: 'Rückgängig', handler: undoHandler });
-  }
-
-  // Tag reserved for undo/redo feedback toasts so they replace one another instead
-  // of stacking when several actions are reverted in quick succession.
-  static readonly UNDO_REDO_TAG = 'undo-redo';
-
-  /**
-   * A4: dezenter Toast nach Undo/Redo. Nennt die konkret geänderte Einstellung und
-   * bietet optional eine "Änderung anzeigen"-Aktion, die zum betroffenen Feld springt.
-   * Ersetzt einen ggf. noch sichtbaren Undo/Redo-Toast (Single-Slot via Tag).
-   */
-  showUndoRedo(message: string, action?: ToastAction, duration = 5000): void {
-    this.show(message, 'info', duration, action, ToastService.UNDO_REDO_TAG);
   }
 
   success(message: string, duration?: number): void {

--- a/src/app/services/toast.service.ts
+++ b/src/app/services/toast.service.ts
@@ -1,11 +1,17 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 
+export interface ToastAction {
+  label: string;
+  handler: () => void;
+}
+
 export interface Toast {
   id: number;
   message: string;
   type: 'success' | 'error' | 'info' | 'warning';
   duration?: number;
+  action?: ToastAction; // optional inline action button (e.g. "Rückgängig")
 }
 
 @Injectable({
@@ -16,12 +22,13 @@ export class ToastService {
   public toasts$ = this.toastsSubject.asObservable();
   private nextId = 0;
 
-  show(message: string, type: Toast['type'] = 'info', duration = 5000): void {
+  show(message: string, type: Toast['type'] = 'info', duration = 5000, action?: ToastAction): void {
     const toast: Toast = {
       id: this.nextId++,
       message,
       type,
       duration,
+      action,
     };
 
     const currentToasts = this.toastsSubject.getValue();
@@ -33,6 +40,14 @@ export class ToastService {
         this.remove(toast.id);
       }, duration);
     }
+  }
+
+  /**
+   * Confirmation toast for a reversible action, with an inline "Rückgängig" button.
+   * Defaults to a 6s window before auto-dismiss.
+   */
+  showUndo(message: string, undoHandler: () => void, duration = 6000): void {
+    this.show(message, 'info', duration, { label: 'Rückgängig', handler: undoHandler });
   }
 
   success(message: string, duration?: number): void {

--- a/src/app/services/toast.service.ts
+++ b/src/app/services/toast.service.ts
@@ -12,6 +12,10 @@ export interface Toast {
   type: 'success' | 'error' | 'info' | 'warning';
   duration?: number;
   action?: ToastAction; // optional inline action button (e.g. "Rückgängig")
+  // Optional category. Toasts sharing a tag never stack: showing a new one with a
+  // given tag removes any currently visible toast that carries the same tag, so
+  // e.g. rapid undo/redo actions replace one another instead of piling up.
+  tag?: string;
 }
 
 @Injectable({
@@ -22,16 +26,21 @@ export class ToastService {
   public toasts$ = this.toastsSubject.asObservable();
   private nextId = 0;
 
-  show(message: string, type: Toast['type'] = 'info', duration = 5000, action?: ToastAction): void {
+  show(message: string, type: Toast['type'] = 'info', duration = 5000, action?: ToastAction, tag?: string): void {
     const toast: Toast = {
       id: this.nextId++,
       message,
       type,
       duration,
       action,
+      tag,
     };
 
-    const currentToasts = this.toastsSubject.getValue();
+    // Same-tag toasts do not stack: drop any currently visible one first so only
+    // the latest is shown (single-slot behaviour for undo/redo feedback).
+    const currentToasts = tag
+      ? this.toastsSubject.getValue().filter(t => t.tag !== tag)
+      : this.toastsSubject.getValue();
     this.toastsSubject.next([...currentToasts, toast]);
 
     // Auto-remove after duration
@@ -48,6 +57,19 @@ export class ToastService {
    */
   showUndo(message: string, undoHandler: () => void, duration = 6000): void {
     this.show(message, 'info', duration, { label: 'Rückgängig', handler: undoHandler });
+  }
+
+  // Tag reserved for undo/redo feedback toasts so they replace one another instead
+  // of stacking when several actions are reverted in quick succession.
+  static readonly UNDO_REDO_TAG = 'undo-redo';
+
+  /**
+   * A4: dezenter Toast nach Undo/Redo. Nennt die konkret geänderte Einstellung und
+   * bietet optional eine "Änderung anzeigen"-Aktion, die zum betroffenen Feld springt.
+   * Ersetzt einen ggf. noch sichtbaren Undo/Redo-Toast (Single-Slot via Tag).
+   */
+  showUndoRedo(message: string, action?: ToastAction, duration = 5000): void {
+    this.show(message, 'info', duration, action, ToastService.UNDO_REDO_TAG);
   }
 
   success(message: string, duration?: number): void {

--- a/src/app/shared/components/toast/toast.component.ts
+++ b/src/app/shared/components/toast/toast.component.ts
@@ -1,6 +1,6 @@
 import { Component } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ToastService } from '../../../services/toast.service';
+import { Toast, ToastService } from '../../../services/toast.service';
 
 @Component({
   selector: 'app-toast',
@@ -33,6 +33,11 @@ import { ToastService } from '../../../services/toast.service';
             }
           </span>
           <span class="toast-message">{{ toast.message }}</span>
+          @if (toast.action) {
+            <button class="toast-action" (click)="runAction(toast, $event)" type="button">
+              {{ toast.action.label }}
+            </button>
+          }
           <button class="toast-close" (click)="remove(toast.id)" type="button">×</button>
         </div>
       }
@@ -103,6 +108,25 @@ import { ToastService } from '../../../services/toast.service';
         line-height: 1.4;
       }
 
+      .toast-action {
+        background: rgba(255, 255, 255, 0.22);
+        border: 1px solid rgba(255, 255, 255, 0.6);
+        color: white;
+        font-size: 13px;
+        font-weight: 700;
+        text-transform: uppercase;
+        letter-spacing: 0.03em;
+        cursor: pointer;
+        padding: 5px 12px;
+        border-radius: 5px;
+        flex-shrink: 0;
+        transition: background-color 0.15s ease;
+      }
+
+      .toast-action:hover {
+        background: rgba(255, 255, 255, 0.35);
+      }
+
       .toast-close {
         background: none;
         border: none;
@@ -135,5 +159,12 @@ export class ToastComponent {
 
   remove(id: number): void {
     this.toastService.remove(id);
+  }
+
+  runAction(toast: Toast, event: Event): void {
+    // Prevent the container's click-to-dismiss from firing before the handler.
+    event.stopPropagation();
+    toast.action?.handler();
+    this.remove(toast.id);
   }
 }


### PR DESCRIPTION
## Ticket A4 – Rückgängigmachen und Zurücksetzen


### Was gemacht
- Snapshot-Stack in `preprocessing.service.ts` über die undoable Teilmenge des State (Datei, Spalten-Configs als Deep-Copy, Cleaning/Projektion, Glyph-/Tooltip-Features, Farbskala). Transiente Felder (currentStep, isProcessing, error, processedDataset) ausgenommen, damit Undo nicht den Schritt wechselt. `undo()/redo()`, `canUndo/canRedo`, `history$` (Labels), `stateRestored$`. Push nur bei abgeschlossenen Aktionen.
- Toolbar oben rechts im Arbeitsbereich mit gebogenen Material-Icons `undo`/`redo` (deaktiviert wenn leer, Tooltip nennt die konkrete Aktion). Klar getrennt von der unveränderten Back/Weiter-Navigation unten (Position + gebogene vs. eckige Icons).
- Tastenkürzel Strg+Z / Strg+Umschalt+Z (+ Strg+Y) global; in Eingabefeldern/Textareas/Select bleibt das native Undo erhalten.
- Toast mit „Rückgängig"-Aktion (Auto-Dismiss 6 s) für riskante Aktionen: Re-Upload (Step 1), Smart Defaults (Step 4), Filter leeren (Step 3).

### Manuelle Testschritte (Schritt → Location → Erwartung)
- CSV laden, Step 2 Spalte abwählen → Toolbar oben rechts → Undo aktiv, Tooltip „Rückgängig: Spalte abgewählt"; Undo → Spalte zurück; Redo möglich.
- Strg+Z / Strg+Umschalt+Z außerhalb eines Eingabefelds → gleiche Wirkung; Fokus im Suchfeld + Strg+Z → natives Feld-Undo.
- Step 1 „Upload Different File" + neue CSV → Toast „Datei ersetzt" + Rückgängig → alte Daten zurück.
- Step 4 „Smart Suggestions" → Toast „Empfohlene Merkmale angewendet"; Undo → alte Feature-Reihenfolge.
- Step 3 Filter setzen + „Clear Filters" → Toast „Filter zurückgesetzt" → Undo stellt Filter wieder her.

Build: `npm run build` erfolgreich (nur vorbestehende Bundle-Budget-Warnung).
