### PR TITLE
A1 + A11: Erklärungen (visuelle Projektions-Tooltips) und Defekt-Fixes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,27 +26,27 @@ Integrations-Branch `feature/wizard-redesign` von `main` abzweigen. Pro Ticket e
 
 | Ticket | Kurztitel | Typ | Status | Branch | Hauptort im Code |
 |--------|-----------|-----|--------|--------|------------------|
-| A1 | Fachbegriffe/Optionen erklären | Konzept | TODO | `feat/a1-erklaertexte` | `shared/constants/help-text.ts`, `shared/help-tooltip/`, Step 3+4 |
+| A1 | Fachbegriffe/Optionen erklären | Konzept | In Progress | `feat/a1-a11-erklaerungen-defekte` | `shared/constants/help-text.ts`, `shared/help-tooltip/`, `shared/projection-preview/`, Step 3+4 |
 | A2 | Voreinstellungen sichtbar/umkehrbar | Konzept | In Feature-Branch | `feat/a2-smart-defaults` | Step 2+3, `services/preprocessing.service.ts` |
 | A3 | Fehlermeldungen inline/verständlich | Konzept | In Feature-Branch | `feat/a3-fehleranzeige` | Step 4+5 |
-| A4 | Undo/Zurücksetzen | Konzept | In Progress | `feat/a4-undo-historie` | `services/preprocessing.service.ts`, Step 1+4 |
+| A4 | Undo/Zurücksetzen | Konzept | In Feature-Branch | `feat/a4-undo-historie` | `services/preprocessing.service.ts`, Step 1+4 |
 | A5 | Zusammengehöriges gruppieren | Konzept | In Feature-Branch | `feat/a5-gruppierung` | Step 3+4 |
 | A6 | Review-Navigation (Direktsprünge) | Konzept | In Feature-Branch | `feat/a6-direct-links` | Step 5, `shared/progress-stepper/` |
 | A7 | Ehrliche/konsistente Signifier | trivial | In Feature-Branch | `feat/a10-a7-polish` | Step 1/2/4, `shared/progress-stepper/` |
 | A8 | Systemstatus/Datenanzeige korrekt | trivial | In Feature-Branch | `feat/a8-datenanzeige` | Step 2+4 |
 | A9 | Beschleuniger für Power-Nutzer | Konzept | In Feature-Branch | `feat/a9-power-shortcuts` | Step 2/3/4 |
 | A10 | Layout gegen lange/viele Inhalte | Konzept | In Feature-Branch | `feat/a10-a7-polish` | Step 1+4, `shared/_wizard-shared.scss` |
-| A11 | Technische Defekte beheben | trivial | TODO | `feat/a11-bugfixes` | siehe Ticket |
+| A11 | Technische Defekte beheben | trivial | In Progress | `feat/a1-a11-erklaerungen-defekte` | siehe Ticket |
 | A12 | Zweispaltiges Layout | Konzept | In Feature-Branch | `feat/a12-two-column` | `preprocessing-wizard.component.*`, `shared/progress-stepper/` |
 | A13 | Schrittlogik klären/neu ordnen | Konzept | In Feature-Branch | `feat/a13-schrittlogik` | Step 2/3/4, `shared/constants/step-info.ts` |
 | A14 | Übergänge sichtbar (Animation) | Konzept | In Feature-Branch | `feat/a14-animation` | Step 2↔3, `shared/data-preview-table/` |
 | A15 | Einheitliches Tabellen/Listen-System | Konzept | In Feature-Branch | `feat/a15-table-system` | `shared/data-preview-table/`, Step 2/3/4 |
 
 **Aktueller Stand (Integrations-Branch `feature/wizard-redesign`):**
-- Gemergt (In Feature-Branch): A2, A3, A5, A6, A7, A8, A9, A10, A12, A13, A14, A15.
-- In Arbeit: A4 (PR #82 offen und gepusht, noch nicht gemergt).
-- Offen (TODO): A1 (Erklärtexte), A11 (technische Defekte — der Persistent-Result-Teil P-S5-02/03 wurde bereits über A3 abgedeckt).
-- A7 und A10 wurden gebündelt im gemeinsamen Branch `feat/a10-a7-polish` umgesetzt.
+- Gemergt (In Feature-Branch): A2, A3, A4, A5, A6, A7, A8, A9, A10, A12, A13, A14, A15.
+- In Arbeit: A1 und A11 (gebündelt in `feat/a1-a11-erklaerungen-defekte`, PR #83 offen).
+- Offen (TODO): keine — alle Tickets sind gemergt oder in Arbeit.
+- Gebündelt umgesetzt: A7+A10 in `feat/a10-a7-polish`; A1+A11 in `feat/a1-a11-erklaerungen-defekte`.
 
 ---
 
@@ -99,7 +99,7 @@ Quick Wins ohne Abhängigkeit, die sich parallel zum Fundament wegräumen lassen
 ---
 
 ## A1 – Fachbegriffe und Optionen verständlich erklären
-**Typ:** Konzept · **Miro:** Visual Tooltips Methoden · **Status:** TODO · **Branch:** `feat/a1-erklaertexte`
+**Typ:** Konzept · **Miro:** Visual Tooltips Methoden · **Status:** In Progress (PR #83 offen, gebündelt mit A11) · **Branch:** `feat/a1-a11-erklaerungen-defekte`
 **Befunde:** C-S4-01, C-S4-03, C-S4-08, C-S4-10, S-S3-02, S-S3-04, P-S3-04
 
 **Problem:** Fachbegriffe werden ohne Erklärung angeboten (Farbattribut, Projektionsmethoden, FastMap, Ausreißermethoden, Z-Wert-Standardisierung, Smart Defaults).
@@ -143,7 +143,7 @@ Quick Wins ohne Abhängigkeit, die sich parallel zum Fundament wegräumen lassen
 ---
 
 ## A4 – Rückgängigmachen und Zurücksetzen anbieten
-**Typ:** Konzept · **Miro:** Historie einführen · **Status:** In Progress (PR #82 offen und gepusht, noch nicht gemergt) · **Branch:** `feat/a4-undo-historie`
+**Typ:** Konzept · **Miro:** Historie einführen · **Status:** In Feature-Branch (PR #82 gemergt) · **Branch:** `feat/a4-undo-historie`
 **Befunde:** C-S1-02, C-S4-09, P-S3-01
 **Tests:** Automatisierte Tests für das Undo/Redo-Feature ergänzt (Testsuite grün).
 
@@ -236,7 +236,7 @@ Quick Wins ohne Abhängigkeit, die sich parallel zum Fundament wegräumen lassen
 ---
 
 ## A11 – Technische Defekte beheben
-**Typ:** trivial · **Miro:** Visual Tooltips Methoden, NEU: Persistent Result Screen + Errorhandling · **Status:** TODO · **Branch:** `feat/a11-bugfixes`
+**Typ:** trivial · **Miro:** Visual Tooltips Methoden, NEU: Persistent Result Screen + Errorhandling · **Status:** In Progress (PR #83 offen, gebündelt mit A1) · **Branch:** `feat/a1-a11-erklaerungen-defekte`
 **Befunde:** C-S3-04, C-S4-04, S-S4-02, P-S5-02, P-S5-03
 
 **Problem/Wo je Defekt:**

--- a/src/app/preprocessing-wizard/preprocessing-wizard.component.ts
+++ b/src/app/preprocessing-wizard/preprocessing-wizard.component.ts
@@ -221,15 +221,20 @@ export class PreprocessingWizardComponent implements OnInit, OnDestroy {
     // instead of just appearing. It starts translated fully up (clipped by the
     // config-shell's overflow:hidden) so it emerges from the top edge. Transform
     // only -> smooth; the start state is applied synchronously before the paint.
+    // clearProps: 'transform' is essential — GSAP.from() otherwise leaves an
+    // inline transform on completion, and any element with a transform becomes
+    // the containing block for its position:fixed descendants. That would make
+    // the fixed help tooltips inside .detail-well position relative to the well
+    // (drifting into a corner) instead of the viewport.
     const railHeader = container.querySelector<HTMLElement>('.rail-header');
     if (railHeader) {
-      timeline.from(railHeader, { yPercent: -100, duration: 0.5, ease: 'power2.out' }, 0);
+      timeline.from(railHeader, { yPercent: -100, duration: 0.5, ease: 'power2.out', clearProps: 'transform' }, 0);
     }
 
     // The detail/config well slides in from the right as one block.
     const well = container.querySelector<HTMLElement>('.detail-well');
     if (well) {
-      timeline.from(well, { xPercent: 40, duration: 0.6, ease: 'power2.out' }, 0);
+      timeline.from(well, { xPercent: 40, duration: 0.6, ease: 'power2.out', clearProps: 'transform' }, 0);
     }
   }
 

--- a/src/app/preprocessing-wizard/shared/constants/help-text.ts
+++ b/src/app/preprocessing-wizard/shared/constants/help-text.ts
@@ -385,7 +385,7 @@ export const HELP_TEXT = {
     missingValues:
       'Controls how missing data is handled.<br/><br/><strong>Keep:</strong> Keep them as-is<br/><strong>Remove rows:</strong> Remove rows containing them<br/><strong>Fill mode:</strong> Fill with the most common value<br/><strong>Fill value:</strong> Fill with a custom value',
     outliers:
-      'Controls how extreme values are handled.<br/><br/>Outliers can be detected using the <strong>interquartile range (IQR)</strong> or <strong>z-Score</strong> (measuring how far a value is from the mean in standard deviations).<br/><br/><strong>Keep:</strong> Keep outliers<br/><strong>Remove:</strong> Remove rows with outliers<br/><strong>Cap:</strong> Limit values to the threshold',
+      "Controls how extreme values are handled. Two detection principles:<br/><br/><strong>IQR</strong> — compares values to the data's quartiles; good for skewed / non-normal data.<br/><strong>Z-Score</strong> — standard deviations from the mean; good for roughly normal data.<br/><br/>The label (Strict / Moderate / Relaxed) only describes how aggressive the threshold is <em>within</em> a method, so the same label can appear for both.<br/><br/><strong>Keep</strong> / <strong>Remove</strong> / <strong>Cap</strong> decide what happens to detected outliers.",
   },
 
   // General concepts
@@ -418,6 +418,10 @@ export const HELP_TEXT = {
       • <strong>Numeric:</strong> Creates a continuous color gradient (e.g., blue to red)<br/>
       • <strong>Categorical:</strong> Assigns distinct colors to each category<br/><br/>
       <em>Optional - leave unselected for uniform color across all glyphs</em>`,
+
+    colorScale: `<strong>Color Scale</strong> is the palette used to map the color feature onto the glyphs.<br/><br/>
+      It is <strong>purely cosmetic</strong> — it only changes how the visualization looks, not the underlying data or the projection.<br/><br/>
+      <em>Pick a gradient for numeric features or a set of distinct colors for categories.</em>`,
 
     projection: `<strong>What is dimensionality reduction?</strong><br/><br/>
       Your data might have dozens or hundreds of dimensions (columns). Dimensionality reduction creates a 2D visualization that preserves important patterns and relationships.<br/><br/>

--- a/src/app/preprocessing-wizard/shared/help-tooltip/help-tooltip.component.html
+++ b/src/app/preprocessing-wizard/shared/help-tooltip/help-tooltip.component.html
@@ -2,7 +2,7 @@
   <button
     class="help-icon"
     (mouseenter)="showTooltip()"
-    (mouseleave)="hideTooltip()"
+    (mouseleave)="scheduleHide()"
     (click)="toggleTooltip()"
     (keydown.enter)="toggleTooltip()"
     (keydown.space)="toggleTooltip()"
@@ -19,6 +19,8 @@
     class="tooltip-content"
     [class.visible]="isVisible"
     [ngStyle]="tooltipStyle"
+    (mouseenter)="cancelScheduledHide()"
+    (mouseleave)="scheduleHide()"
     role="tooltip"
     [attr.aria-hidden]="!isVisible"
   >

--- a/src/app/preprocessing-wizard/shared/help-tooltip/help-tooltip.component.scss
+++ b/src/app/preprocessing-wizard/shared/help-tooltip/help-tooltip.component.scss
@@ -17,13 +17,16 @@
   color: v.$gray-600;
   transition: color 0.2s ease;
 
-  &:hover,
-  &:focus {
+  &:hover {
     color: v.$active-color;
+  }
+
+  &:focus {
     outline: none;
   }
 
   &:focus-visible {
+    color: v.$active-color;
     outline: 2px solid v.$active-color;
     outline-offset: 2px;
     border-radius: 50%;

--- a/src/app/preprocessing-wizard/shared/help-tooltip/help-tooltip.component.ts
+++ b/src/app/preprocessing-wizard/shared/help-tooltip/help-tooltip.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, HostListener, ElementRef, ViewChild, ChangeDetectorRef } from '@angular/core';
+import { Component, Input, HostListener, ElementRef, ViewChild, ChangeDetectorRef, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Component({
@@ -8,7 +8,7 @@ import { CommonModule } from '@angular/common';
   templateUrl: './help-tooltip.component.html',
   styleUrl: './help-tooltip.component.scss',
 })
-export class HelpTooltipComponent {
+export class HelpTooltipComponent implements OnDestroy {
   @Input() helpText = '';
   @Input() position: 'top' | 'bottom' | 'left' | 'right' = 'top';
   @ViewChild('tooltipContent') tooltipContent!: ElementRef;
@@ -16,12 +16,24 @@ export class HelpTooltipComponent {
   isVisible = false;
   tooltipStyle: Record<string, string> = {};
 
+  // Grace period before hiding, so the pointer can travel from the icon into
+  // the tooltip (e.g. to read the content or watch a preview animation) without
+  // it disappearing. Cancelled as soon as the pointer enters the tooltip.
+  private hideTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly HIDE_DELAY_MS = 180;
+
   constructor(
     private elementRef: ElementRef,
     private cdr: ChangeDetectorRef
   ) {}
 
   showTooltip(): void {
+    this.cancelScheduledHide();
+    // Park off-screen until positioned, so it never briefly overflows the
+    // viewport (which would flash a horizontal scrollbar) on first show.
+    if (!this.tooltipStyle['left']) {
+      this.tooltipStyle = { top: '-9999px', left: '-9999px' };
+    }
     this.isVisible = true;
     this.updateTooltipPosition();
   }
@@ -30,7 +42,25 @@ export class HelpTooltipComponent {
     this.isVisible = false;
   }
 
+  /** Hide after a short grace period unless the pointer re-enters in time. */
+  scheduleHide(): void {
+    this.cancelScheduledHide();
+    this.hideTimer = setTimeout(() => {
+      this.isVisible = false;
+      this.hideTimer = null;
+      this.cdr.detectChanges();
+    }, HelpTooltipComponent.HIDE_DELAY_MS);
+  }
+
+  cancelScheduledHide(): void {
+    if (this.hideTimer !== null) {
+      clearTimeout(this.hideTimer);
+      this.hideTimer = null;
+    }
+  }
+
   toggleTooltip(): void {
+    this.cancelScheduledHide();
     this.isVisible = !this.isVisible;
     if (this.isVisible) {
       this.updateTooltipPosition();
@@ -73,16 +103,19 @@ export class HelpTooltipComponent {
           break;
       }
 
-      // Keep tooltip within viewport
+      // Keep tooltip within viewport. Use clientWidth/Height (excludes the
+      // scrollbars) so clamping never leaves the tooltip poking past the edge.
       const padding = 10;
+      const viewW = document.documentElement.clientWidth;
+      const viewH = document.documentElement.clientHeight;
+      if (left + tooltipRect.width > viewW - padding) {
+        left = viewW - tooltipRect.width - padding;
+      }
       if (left < padding) left = padding;
-      if (left + tooltipRect.width > window.innerWidth - padding) {
-        left = window.innerWidth - tooltipRect.width - padding;
+      if (top + tooltipRect.height > viewH - padding) {
+        top = viewH - tooltipRect.height - padding;
       }
       if (top < padding) top = padding;
-      if (top + tooltipRect.height > window.innerHeight - padding) {
-        top = window.innerHeight - tooltipRect.height - padding;
-      }
 
       this.tooltipStyle = {
         top: `${top}px`,
@@ -103,5 +136,9 @@ export class HelpTooltipComponent {
   @HostListener('keydown.escape')
   onEscapeKey(): void {
     this.isVisible = false;
+  }
+
+  ngOnDestroy(): void {
+    this.cancelScheduledHide();
   }
 }

--- a/src/app/preprocessing-wizard/shared/projection-preview/projection-preview.component.html
+++ b/src/app/preprocessing-wizard/shared/projection-preview/projection-preview.component.html
@@ -1,0 +1,49 @@
+<div class="projection-preview-container">
+  <button
+    class="preview-icon"
+    type="button"
+    tabindex="0"
+    [attr.aria-label]="'Preview: ' + methodKey"
+    [attr.aria-expanded]="isOpen"
+    (mouseenter)="open()"
+    (mouseleave)="scheduleHide()"
+    (click)="toggle(); $event.stopPropagation()"
+    (keydown.enter)="toggle(); $event.stopPropagation()"
+    (keydown.space)="toggle(); $event.stopPropagation()"
+  >
+    <span class="material-icons">help_outline</span>
+  </button>
+
+  @if (isOpen) {
+    <div
+      class="projection-preview"
+      [ngStyle]="popupStyle"
+      role="tooltip"
+      (mouseenter)="cancelScheduledHide()"
+      (mouseleave)="scheduleHide()"
+    >
+      <div class="preview-head">
+        <span class="preview-name">{{ meta.name }}</span>
+        <span class="preview-tag" [ngClass]="'tag-' + meta.tagClass">{{ meta.tag }}</span>
+        @if (meta.rows) {
+          <span class="preview-rows">{{ meta.rows }}</span>
+        }
+      </div>
+      <div class="preview-sub">{{ meta.sub }}</div>
+      <div class="preview-desc">{{ meta.desc }}</div>
+
+      <div class="preview-canvas-wrap">
+        <canvas #cnv></canvas>
+      </div>
+
+      <div class="preview-caption">
+        <span class="preview-dots">
+          @for (step of caps; track $index) {
+            <span class="dot" [class.active]="$index === currentPhase"></span>
+          }
+        </span>
+        <span class="preview-cap-text">{{ caps[currentPhase]?.cap }}</span>
+      </div>
+    </div>
+  }
+</div>

--- a/src/app/preprocessing-wizard/shared/projection-preview/projection-preview.component.scss
+++ b/src/app/preprocessing-wizard/shared/projection-preview/projection-preview.component.scss
@@ -1,0 +1,167 @@
+@use '../../../../styles/variables' as v;
+
+.projection-preview-container {
+  position: relative;
+  display: inline-flex;
+  vertical-align: middle;
+}
+
+.preview-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 2px;
+  color: v.$gray-600;
+  transition: color 0.2s ease;
+
+  &:hover {
+    color: v.$active-color;
+  }
+
+  &:focus {
+    outline: none;
+  }
+
+  &:focus-visible {
+    color: v.$active-color;
+    outline: 2px solid v.$active-color;
+    outline-offset: 2px;
+    border-radius: 50%;
+  }
+
+  .material-icons {
+    font-size: 18px;
+  }
+}
+
+.projection-preview {
+  position: fixed;
+  z-index: 10000;
+  width: 372px;
+  max-width: 372px;
+  box-sizing: border-box;
+  background: #fff;
+  border: 1px solid v.$gray-300;
+  border-radius: 12px;
+  box-shadow: 0 14px 32px -10px rgba(20, 40, 60, 0.25);
+  padding: 16px;
+  text-align: left;
+}
+
+.preview-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.preview-name {
+  font-size: 16px;
+  font-weight: 700;
+  color: v.$gray-800;
+}
+
+.preview-tag {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  padding: 2px 7px;
+  border-radius: 5px;
+  white-space: nowrap;
+
+  &.tag-primary {
+    background: rgba(0, 188, 212, 0.15);
+    color: v.$status-info;
+  }
+
+  &.tag-fast {
+    background: rgba(31, 122, 69, 0.13);
+    color: #1f7a45;
+  }
+
+  &.tag-medium {
+    background: rgba(181, 106, 0, 0.15);
+    color: #b56a00;
+  }
+
+  &.tag-slow {
+    background: rgba(178, 58, 34, 0.13);
+    color: #b23a22;
+  }
+}
+
+.preview-rows {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  border: 1px solid v.$gray-300;
+  color: v.$gray-600;
+  white-space: nowrap;
+}
+
+.preview-sub {
+  font-size: 11.5px;
+  color: v.$gray-500;
+  margin-top: 2px;
+}
+
+.preview-desc {
+  font-size: 12.5px;
+  color: v.$gray-700;
+  margin-top: 8px;
+  line-height: 1.45;
+}
+
+.preview-canvas-wrap {
+  margin-top: 12px;
+  background: v.$gray-100;
+  border: 1px solid v.$gray-200;
+  border-radius: 8px;
+  overflow: hidden;
+
+  canvas {
+    display: block;
+    width: 340px;
+    height: 200px;
+    max-width: 100%;
+  }
+}
+
+.preview-caption {
+  margin-top: 11px;
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-height: 34px;
+}
+
+.preview-dots {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  flex-shrink: 0;
+
+  .dot {
+    width: 5px;
+    height: 5px;
+    border-radius: 3px;
+    background: v.$gray-300;
+    transition: all 0.35s ease;
+
+    &.active {
+      width: 18px;
+      background: v.$active-color;
+    }
+  }
+}
+
+.preview-cap-text {
+  font-size: 12.5px;
+  color: v.$gray-600;
+  line-height: 1.35;
+}

--- a/src/app/preprocessing-wizard/shared/projection-preview/projection-preview.component.ts
+++ b/src/app/preprocessing-wizard/shared/projection-preview/projection-preview.component.ts
@@ -1,0 +1,1397 @@
+import { Component, Input, ViewChild, ElementRef, OnDestroy, HostListener, ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
+/**
+ * Metadata for one projection method's preview.
+ */
+interface PreviewMeta {
+  name: string;
+  tag: string;
+  /** Tag colour class suffix used for the badge styling. */
+  tagClass: 'fast' | 'medium' | 'slow' | 'primary';
+  rows: string;
+  sub: string;
+  desc: string;
+}
+
+interface CaptionStep {
+  /** Relative duration of this step in the loop. */
+  d: number;
+  cap: string;
+}
+
+/**
+ * Animated, looping canvas preview of a single dimensionality-reduction method.
+ *
+ * The drawing engine (geometry generators + per-method draw routines) is ported
+ * from the ClaudeDesign "Projection Previews" template. Unlike the template,
+ * which animates all methods at once, this component builds and animates exactly
+ * one method — the one named by {@link methodKey} — so it is cheap enough to
+ * mount inside a per-method tooltip and it only runs while it is on screen.
+ */
+@Component({
+  selector: 'app-projection-preview',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './projection-preview.component.html',
+  styleUrl: './projection-preview.component.scss',
+})
+export class ProjectionPreviewComponent implements OnDestroy {
+  /** Preview key: fast | pca | tri | mds | iso | lle | ltsa | topo | umap | sammon | tsne */
+  @Input({ required: true }) methodKey!: string;
+  @Input() position: 'top' | 'bottom' | 'left' | 'right' = 'left';
+
+  @ViewChild('cnv') canvasRef?: ElementRef<HTMLCanvasElement>;
+
+  // Exposed to the template.
+  meta!: PreviewMeta;
+  caps: CaptionStep[] = [];
+  currentPhase = 0;
+  isOpen = false;
+  popupStyle: Record<string, string> = {};
+
+  readonly W = 340;
+  readonly H = 200;
+  private readonly cx = 170;
+  private readonly cy = 100;
+  private readonly accent = '#00bcd4';
+  /** Playback speed multiplier for the looping animation. */
+  private readonly speed = 0.5;
+
+  private eng: any = null;
+  private clock = 0;
+  private last = 0;
+  private rafId: number | null = null;
+
+  // Grace period so the pointer can travel from the icon into the popup
+  // (to read the description or watch the animation) without it closing.
+  private hideTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly HIDE_DELAY_MS = 180;
+
+  private readonly META: Record<string, PreviewMeta> = {
+    fast: {
+      name: 'FastMap',
+      tag: 'Always active',
+      tagClass: 'primary',
+      rows: '',
+      sub: 'Pivot-based linear projection',
+      desc: 'The default projection — always on, loads immediately, and is shown while slower methods compute in the background.',
+    },
+    pca: {
+      name: 'PCA',
+      tag: 'Very fast',
+      tagClass: 'fast',
+      rows: 'Any size',
+      sub: 'Principal Component Analysis',
+      desc: 'Fast and linear — captures the directions of greatest variance.',
+    },
+    tri: {
+      name: 'TriMap',
+      tag: 'Fast',
+      tagClass: 'fast',
+      rows: 'Up to 100K rows',
+      sub: 'Triplet-based dimensionality reduction',
+      desc: 'Learns from point triplets to keep the global layout honest.',
+    },
+    mds: {
+      name: 'MDS',
+      tag: 'Medium',
+      tagClass: 'medium',
+      rows: 'Up to 5K rows',
+      sub: 'Classical Multidimensional Scaling',
+      desc: 'Arranges points so pairwise distances match the original data.',
+    },
+    iso: {
+      name: 'IsoMap',
+      tag: 'Medium',
+      tagClass: 'medium',
+      rows: 'Up to 5K rows',
+      sub: 'Isometric Mapping',
+      desc: 'Measures distances along the manifold, then unrolls it flat.',
+    },
+    lle: {
+      name: 'LLE',
+      tag: 'Medium',
+      tagClass: 'medium',
+      rows: 'Up to 30K rows',
+      sub: 'Locally Linear Embedding',
+      desc: 'Rebuilds each point from its neighbors, keeping local geometry.',
+    },
+    ltsa: {
+      name: 'LTSA',
+      tag: 'Medium',
+      tagClass: 'medium',
+      rows: 'Up to 20K rows',
+      sub: 'Local Tangent Space Alignment',
+      desc: 'Aligns local tangent spaces to flatten curved manifolds.',
+    },
+    topo: {
+      name: 'TopoMap',
+      tag: 'Medium',
+      tagClass: 'medium',
+      rows: 'Up to 8K rows',
+      sub: 'Topology-preserving mapping via MST',
+      desc: 'Builds a minimum spanning tree and preserves its topology.',
+    },
+    umap: {
+      name: 'UMAP',
+      tag: 'Slow',
+      tagClass: 'slow',
+      rows: 'Up to 100K rows',
+      sub: 'Uniform Manifold Approximation & Projection',
+      desc: 'Balances local detail with the global layout of the data.',
+    },
+    sammon: {
+      name: 'Sammon',
+      tag: 'Slow',
+      tagClass: 'slow',
+      rows: 'Up to 5K rows',
+      sub: 'Sammon Mapping',
+      desc: 'Like MDS, but small distances count the most.',
+    },
+    tsne: {
+      name: 't-SNE',
+      tag: 'Very slow',
+      tagClass: 'slow',
+      rows: 'Up to 15K rows',
+      sub: 't-Distributed Stochastic Neighbor Embedding',
+      desc: 'Focuses on local neighborhoods to reveal tight clusters.',
+    },
+  };
+
+  private readonly CAPS: Record<string, CaptionStep[]> = {
+    fast: [
+      { d: 1.1, cap: 'Your data — many variables at once' },
+      { d: 1.7, cap: 'Pick two far-apart pivot points' },
+      { d: 1.4, cap: 'The pivots define an axis' },
+      { d: 1.9, cap: 'Place each point by its distance to the pivots' },
+      { d: 1.7, cap: 'A fast linear layout — ready instantly' },
+    ],
+    pca: [
+      { d: 1.1, cap: 'Your data — many variables at once' },
+      { d: 1.9, cap: 'Finding the direction of greatest variance' },
+      { d: 0.8, cap: 'Main axis locked in' },
+      { d: 1.9, cap: 'Projecting every point onto that axis' },
+      { d: 1.7, cap: 'Fewer dimensions — the spread is kept' },
+    ],
+    tri: [
+      { d: 1.1, cap: 'Your data — many variables at once' },
+      { d: 2.2, cap: 'Sample triplets: A is closer to B than to C' },
+      { d: 2.0, cap: 'Move points to satisfy the triplets' },
+      { d: 1.8, cap: 'Clusters — and the global layout — are kept' },
+    ],
+    mds: [
+      { d: 1.1, cap: 'Your data — many variables at once' },
+      { d: 2.2, cap: 'Measure every pairwise distance' },
+      { d: 1.9, cap: 'Arrange points so distances still match' },
+      { d: 1.6, cap: 'Relative distances are preserved' },
+    ],
+    iso: [
+      { d: 1.2, cap: 'Data lying on a curved manifold' },
+      { d: 1.6, cap: 'Connect each point to its neighbors' },
+      { d: 2.2, cap: 'Distances follow the curve — not the shortcut' },
+      { d: 1.8, cap: 'Unroll the manifold flat' },
+      { d: 1.5, cap: 'Geodesic distances preserved' },
+    ],
+    lle: [
+      { d: 1.2, cap: 'Data lying on a curved manifold' },
+      { d: 2.0, cap: 'Describe each point by its neighbors' },
+      { d: 1.9, cap: 'Unfold, keeping each patch intact' },
+      { d: 1.5, cap: 'Local geometry preserved' },
+    ],
+    ltsa: [
+      { d: 1.2, cap: 'Data lying on a curved manifold' },
+      { d: 1.9, cap: 'Fit a tangent line to each neighborhood' },
+      { d: 2.0, cap: 'Align the tangents into one flat space' },
+      { d: 1.5, cap: 'Curved structure, flattened' },
+    ],
+    topo: [
+      { d: 1.1, cap: 'Your data — many variables at once' },
+      { d: 2.2, cap: 'Build the minimum spanning tree' },
+      { d: 1.9, cap: 'Lay out points, keeping the tree intact' },
+      { d: 1.5, cap: 'Topology preserved' },
+    ],
+    umap: [
+      { d: 1.1, cap: 'High-dimensional data' },
+      { d: 1.7, cap: 'Connect each point to its nearest neighbors' },
+      { d: 2.2, cap: 'Neighbors pull together into groups' },
+      { d: 1.8, cap: 'Clusters — and the gaps between them — stay meaningful' },
+    ],
+    sammon: [
+      { d: 1.1, cap: 'Your data — many variables at once' },
+      { d: 2.0, cap: 'Weigh distances — near pairs matter most' },
+      { d: 1.9, cap: 'Arrange points, pinning close pairs first' },
+      { d: 1.5, cap: 'Small distances preserved' },
+    ],
+    tsne: [
+      { d: 1.1, cap: 'High-dimensional data' },
+      { d: 1.6, cap: 'Measure who sits close to whom' },
+      { d: 2.4, cap: 'Pull neighbors in, push the rest away' },
+      { d: 1.8, cap: 'Tight clusters form — gaps aren’t to scale' },
+    ],
+  };
+
+  constructor(
+    private elementRef: ElementRef,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnDestroy(): void {
+    this.cancelScheduledHide();
+    this.stopAnimation();
+  }
+
+  open(): void {
+    this.cancelScheduledHide();
+    if (this.isOpen) return;
+    const key = this.methodKeyResolved();
+    this.meta = this.META[key];
+    this.caps = this.CAPS[key];
+    if (!this.eng) this.eng = this.buildEngine(key);
+    // Park off-screen until positioned, so the popup never briefly overflows the
+    // viewport (which would flash a horizontal scrollbar) before clamping.
+    this.popupStyle = { top: '-9999px', left: '-9999px' };
+    this.isOpen = true;
+    // Wait for the popup + canvas to render, then size, position and animate.
+    setTimeout(() => {
+      const canvas = this.canvasRef?.nativeElement;
+      if (!canvas) return;
+      this.sizeCanvas(canvas);
+      this.updatePopupPosition();
+      this.clock = 0;
+      this.last = performance.now();
+      this.startAnimation();
+    }, 0);
+  }
+
+  close(): void {
+    this.isOpen = false;
+    this.stopAnimation();
+  }
+
+  toggle(): void {
+    if (this.isOpen) this.close();
+    else this.open();
+  }
+
+  /** Hide after a short grace period unless the pointer re-enters in time. */
+  scheduleHide(): void {
+    this.cancelScheduledHide();
+    this.hideTimer = setTimeout(() => {
+      this.close();
+      this.hideTimer = null;
+      this.cdr.detectChanges();
+    }, ProjectionPreviewComponent.HIDE_DELAY_MS);
+  }
+
+  cancelScheduledHide(): void {
+    if (this.hideTimer !== null) {
+      clearTimeout(this.hideTimer);
+      this.hideTimer = null;
+    }
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (!this.elementRef.nativeElement.contains(event.target)) {
+      this.close();
+    }
+  }
+
+  @HostListener('keydown.escape')
+  onEscapeKey(): void {
+    this.close();
+  }
+
+  private startAnimation(): void {
+    if (this.rafId === null) this.rafId = requestAnimationFrame(this.tick);
+  }
+
+  private stopAnimation(): void {
+    if (this.rafId !== null) {
+      cancelAnimationFrame(this.rafId);
+      this.rafId = null;
+    }
+  }
+
+  private updatePopupPosition(): void {
+    const icon = this.elementRef.nativeElement.querySelector('.preview-icon');
+    const popup = this.elementRef.nativeElement.querySelector('.projection-preview');
+    if (!icon || !popup) return;
+    const rect = icon.getBoundingClientRect();
+    const pRect = popup.getBoundingClientRect();
+    const offset = 10;
+    const padding = 10;
+    let top = 0;
+    let left = 0;
+    switch (this.position) {
+      case 'top':
+        top = rect.top - pRect.height - offset;
+        left = rect.left + rect.width / 2 - pRect.width / 2;
+        break;
+      case 'bottom':
+        top = rect.bottom + offset;
+        left = rect.left + rect.width / 2 - pRect.width / 2;
+        break;
+      case 'right':
+        top = rect.top + rect.height / 2 - pRect.height / 2;
+        left = rect.right + offset;
+        break;
+      case 'left':
+      default:
+        top = rect.top + rect.height / 2 - pRect.height / 2;
+        left = rect.left - pRect.width - offset;
+        break;
+    }
+    const viewW = document.documentElement.clientWidth;
+    const viewH = document.documentElement.clientHeight;
+    if (left + pRect.width > viewW - padding) left = viewW - pRect.width - padding;
+    if (left < padding) left = padding;
+    if (top + pRect.height > viewH - padding) top = viewH - pRect.height - padding;
+    if (top < padding) top = padding;
+    this.popupStyle = { top: `${top}px`, left: `${left}px` };
+    this.cdr.detectChanges();
+  }
+
+  // ---------- deterministic RNG helpers ----------
+  private mulberry(a: number): () => number {
+    return function () {
+      a |= 0;
+      a = (a + 0x6d2b79f5) | 0;
+      let t = Math.imul(a ^ (a >>> 15), 1 | a);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+  }
+  private gaussOf(r: () => number): () => number {
+    return () => {
+      const u1 = r() || 1e-9;
+      const u2 = r();
+      return Math.sqrt(-2 * Math.log(u1)) * Math.cos(6.283185 * u2);
+    };
+  }
+
+  // ---------- colour helpers ----------
+  private hx(h: string): number[] {
+    h = h.replace('#', '');
+    return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)];
+  }
+  private mix(a: string, b: string, t: number): number[] {
+    const p = this.hx(a);
+    const q = this.hx(b);
+    return [p[0] + (q[0] - p[0]) * t, p[1] + (q[1] - p[1]) * t, p[2] + (q[2] - p[2]) * t];
+  }
+  private rgb(c: number[]): string {
+    return 'rgb(' + Math.round(c[0]) + ',' + Math.round(c[1]) + ',' + Math.round(c[2]) + ')';
+  }
+  private rgba(c: number[], a: number): string {
+    return 'rgba(' + Math.round(c[0]) + ',' + Math.round(c[1]) + ',' + Math.round(c[2]) + ',' + a + ')';
+  }
+  private hexA(h: string, a: number): string {
+    return this.rgba(this.hx(h), a);
+  }
+  private lerp(a: number, b: number, t: number): number {
+    return a + (b - a) * t;
+  }
+  private sm(t: number): number {
+    t = Math.max(0, Math.min(1, t));
+    return t * t * (3 - 2 * t);
+  }
+  private grad(t: number): string {
+    return this.rgb(this.mix('#1aa6bf', '#ff7043', Math.max(0, Math.min(1, t))));
+  }
+
+  // ---------- geometry ----------
+  private buildEngine(key: string): any {
+    const W = this.W;
+    const H = this.H;
+    const cx = this.cx;
+    const cy = this.cy;
+    const groupColors = ['#00bcd4', '#ff7043', '#7e57c2'];
+    const mul = (s: number) => this.mulberry(s);
+    const gaussOf = (r: () => number) => this.gaussOf(r);
+    const grad = (t: number) => this.grad(t);
+
+    const genClusters = (centers: any[], spread: number, seed: number, sizes: number[]) => {
+      const r = mul(seed);
+      const g2 = gaussOf(r);
+      const pts: any[] = [];
+      for (let gi = 0; gi < centers.length; gi++) {
+        for (let k = 0; k < sizes[gi]; k++) {
+          const ang = r() * 6.2832;
+          let rad = Math.abs(g2()) * spread;
+          rad = Math.min(rad, spread * 2.4);
+          pts.push({
+            g: gi,
+            cx: cx + centers[gi].x + Math.cos(ang) * rad,
+            cy: cy + centers[gi].y + Math.sin(ang) * rad,
+            sx: cx + (r() * 2 - 1) * 150,
+            sy: cy + (r() * 2 - 1) * 80,
+            jp: r() * 6.283,
+          });
+        }
+      }
+      return pts;
+    };
+
+    const cloudTarget = (seed: number, n: number, rot: number, sy: number) => {
+      const r = mul(seed);
+      const g = gaussOf(r);
+      const pts: any[] = [];
+      for (let i = 0; i < n; i++) {
+        let a = g() * 62;
+        a = Math.max(-105, Math.min(105, a));
+        let b = g() * 34;
+        b = Math.max(-62, Math.min(62, b));
+        const bx = cx + a;
+        const by = cy + b * 0.9;
+        const co = Math.cos(rot);
+        const si = Math.sin(rot);
+        const dx = bx - cx;
+        const dy = by - cy;
+        let px = cx + dx * co - dy * si;
+        let py = cy + (dx * si + dy * co) * sy;
+        px = Math.max(14, Math.min(W - 14, px));
+        py = Math.max(14, Math.min(H - 14, py));
+        pts.push({ bx, by, px, py, color: grad((a + 95) / 190) });
+      }
+      return pts;
+    };
+
+    const curve = (seed: number, n: number, amp: number, freq: number, phase: number) => {
+      const r = mul(seed);
+      const pts: any[] = [];
+      for (let i = 0; i < n; i++) {
+        const t = i / (n - 1);
+        const jx = (r() * 2 - 1) * 4;
+        const jy = (r() * 2 - 1) * 8;
+        pts.push({
+          t,
+          bx: cx + (t - 0.5) * 252 + jx,
+          by: cy + amp * Math.sin((t - 0.5) * freq + (phase || 0)) + jy,
+          ux: cx + (t - 0.5) * 290 + jx,
+          uy: cy + jy * 0.6,
+          color: grad(t),
+        });
+      }
+      return pts;
+    };
+
+    switch (key) {
+      case 'pca': {
+        const rng = mul(20260702);
+        const gauss = gaussOf(rng);
+        const th = -0.384;
+        const ux = Math.cos(th);
+        const uy = Math.sin(th);
+        const vx = -Math.sin(th);
+        const vy = Math.cos(th);
+        const pts: any[] = [];
+        for (let i = 0; i < 46; i++) {
+          let a = gauss() * 58;
+          a = Math.max(-92, Math.min(92, a));
+          let b = gauss() * 15;
+          b = Math.max(-30, Math.min(30, b));
+          pts.push({
+            bx: cx + ux * a + vx * b,
+            by: cy + uy * a + vy * b,
+            px: cx + ux * a,
+            py: cy + uy * a,
+            color: grad((a + 80) / 160),
+          });
+        }
+        return { pts, theta: th };
+      }
+      case 'fast': {
+        const rf = mul(99123);
+        const gf = gaussOf(rf);
+        const pts: any[] = [];
+        for (let i = 0; i < 44; i++) {
+          let a = gf() * 52;
+          a = Math.max(-98, Math.min(98, a));
+          let b = gf() * 30;
+          b = Math.max(-58, Math.min(58, b));
+          pts.push({ bx: cx + a, by: cy + b * 0.92 });
+        }
+        let pi = 0;
+        let pj = 1;
+        let best = -1;
+        for (let i = 0; i < pts.length; i++)
+          for (let j = i + 1; j < pts.length; j++) {
+            const dx = pts[i].bx - pts[j].bx;
+            const dy = pts[i].by - pts[j].by;
+            const d2 = dx * dx + dy * dy;
+            if (d2 > best) {
+              best = d2;
+              pi = i;
+              pj = j;
+            }
+          }
+        const P = pts[pi];
+        const Q = pts[pj];
+        const fdx = Q.bx - P.bx;
+        const fdy = Q.by - P.by;
+        const flen2 = fdx * fdx + fdy * fdy;
+        for (const p of pts) {
+          const t = ((p.bx - P.bx) * fdx + (p.by - P.by) * fdy) / flen2;
+          p.px = P.bx + fdx * t;
+          p.py = P.by + fdy * t;
+          p.color = grad(t);
+        }
+        return { pts, pi, pj, angle: Math.atan2(fdy, fdx) };
+      }
+      case 'umap': {
+        const pts = genClusters(
+          [
+            { x: -92, y: -14 },
+            { x: 80, y: -30 },
+            { x: -4, y: 54 },
+          ],
+          15,
+          777,
+          [16, 15, 15]
+        );
+        const edges: number[][] = [];
+        const seen = new Set<string>();
+        for (let i = 0; i < pts.length; i++) {
+          const cand: number[][] = [];
+          for (let j = 0; j < pts.length; j++) {
+            if (j === i || pts[j].g !== pts[i].g) continue;
+            const dx = pts[i].cx - pts[j].cx;
+            const dy = pts[i].cy - pts[j].cy;
+            cand.push([dx * dx + dy * dy, j]);
+          }
+          cand.sort((a, b) => a[0] - b[0]);
+          for (let m = 0; m < Math.min(2, cand.length); m++) {
+            const j = cand[m][1];
+            const keyE = i < j ? i + '-' + j : j + '-' + i;
+            if (!seen.has(keyE)) {
+              seen.add(keyE);
+              edges.push([i, j]);
+            }
+          }
+        }
+        return { pts, edges, groupColors };
+      }
+      case 'tsne': {
+        const pts = genClusters(
+          [
+            { x: -58, y: -34 },
+            { x: 66, y: -2 },
+            { x: -18, y: 52 },
+          ],
+          9,
+          313,
+          [16, 15, 15]
+        );
+        const cent = [
+          { x: 0, y: 0, n: 0 },
+          { x: 0, y: 0, n: 0 },
+          { x: 0, y: 0, n: 0 },
+        ];
+        for (const p of pts) {
+          cent[p.g].x += p.cx;
+          cent[p.g].y += p.cy;
+          cent[p.g].n++;
+        }
+        cent.forEach(c => {
+          c.x /= c.n;
+          c.y /= c.n;
+        });
+        return { pts, cent, groupColors };
+      }
+      case 'tri': {
+        const pts = genClusters(
+          [
+            { x: -80, y: -20 },
+            { x: 86, y: -18 },
+            { x: 2, y: 52 },
+          ],
+          13,
+          555,
+          [16, 15, 15]
+        );
+        const rt = mul(1212);
+        const triplets: number[][] = [];
+        for (let t = 0; t < 5; t++) {
+          const a = Math.floor(rt() * pts.length);
+          let b = a;
+          while (b === a || pts[b].g !== pts[a].g) b = Math.floor(rt() * pts.length);
+          let c = a;
+          while (pts[c].g === pts[a].g) c = Math.floor(rt() * pts.length);
+          triplets.push([a, b, c]);
+        }
+        const cent = [
+          { x: 0, y: 0, n: 0 },
+          { x: 0, y: 0, n: 0 },
+          { x: 0, y: 0, n: 0 },
+        ];
+        for (const p of pts) {
+          cent[p.g].x += p.cx;
+          cent[p.g].y += p.cy;
+          cent[p.g].n++;
+        }
+        cent.forEach(c => {
+          c.x /= c.n;
+          c.y /= c.n;
+        });
+        return { pts, triplets, cent, groupColors };
+      }
+      case 'topo': {
+        const pts = genClusters(
+          [
+            { x: -84, y: -8 },
+            { x: 70, y: -34 },
+            { x: 10, y: 50 },
+          ],
+          20,
+          888,
+          [12, 12, 12]
+        );
+        const used = new Set<number>([0]);
+        const edges: number[][] = [];
+        while (used.size < pts.length) {
+          let bi = -1;
+          let bj = -1;
+          let bd = Infinity;
+          for (const i of used)
+            for (let j = 0; j < pts.length; j++) {
+              if (used.has(j)) continue;
+              const dx = pts[i].cx - pts[j].cx;
+              const dy = pts[i].cy - pts[j].cy;
+              const d = dx * dx + dy * dy;
+              if (d < bd) {
+                bd = d;
+                bi = i;
+                bj = j;
+              }
+            }
+          used.add(bj);
+          edges.push([bi, bj]);
+        }
+        return { pts, edges, groupColors };
+      }
+      case 'mds': {
+        const pts = cloudTarget(246, 26, -0.45, 0.72);
+        const edges: number[][] = [];
+        const seen = new Set<string>();
+        for (let i = 0; i < pts.length; i++) {
+          const cand: number[][] = [];
+          for (let j = 0; j < pts.length; j++) {
+            if (j === i) continue;
+            const dx = pts[i].bx - pts[j].bx;
+            const dy = pts[i].by - pts[j].by;
+            cand.push([dx * dx + dy * dy, j]);
+          }
+          cand.sort((a, b) => a[0] - b[0]);
+          for (let m = 0; m < 2; m++) {
+            const j = cand[m][1];
+            const keyE = i < j ? i + '-' + j : j + '-' + i;
+            if (!seen.has(keyE)) {
+              seen.add(keyE);
+              edges.push([i, j]);
+            }
+          }
+        }
+        return { pts, edges, anchors: [2, 9, 16, 22, 6, 13] };
+      }
+      case 'sammon': {
+        const pts = cloudTarget(135, 26, 0.4, 0.7);
+        const near: number[][] = [];
+        const far: number[][] = [];
+        for (let i = 0; i < pts.length; i++)
+          for (let j = i + 1; j < pts.length; j++) {
+            const dx = pts[i].bx - pts[j].bx;
+            const dy = pts[i].by - pts[j].by;
+            const d = Math.sqrt(dx * dx + dy * dy);
+            if (d < 40 && near.length < 24) near.push([i, j]);
+            else if (d > 150 && far.length < 6) far.push([i, j]);
+          }
+        return { pts, near, far };
+      }
+      case 'iso':
+        return { pts: curve(41, 34, 60, 4.6, 0) };
+      case 'lle':
+        return { pts: curve(42, 30, 56, 2.6, 0.6), samples: [3, 9, 15, 21, 27] };
+      case 'ltsa':
+        return { pts: curve(43, 30, 46, 5.6, 0), samples: [2, 6, 10, 14, 18, 22, 26] };
+      default:
+        return { pts: [], theta: 0 };
+    }
+  }
+
+  private sizeCanvas(el: HTMLCanvasElement): void {
+    const dpr = Math.min(window.devicePixelRatio || 1, 2);
+    el.width = this.W * dpr;
+    el.height = this.H * dpr;
+    el.style.width = this.W + 'px';
+    el.style.height = this.H + 'px';
+    el.getContext('2d')!.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  // ---------- drawing primitives ----------
+  private grid(ctx: CanvasRenderingContext2D): void {
+    ctx.save();
+    ctx.fillStyle = 'rgba(120,140,160,0.06)';
+    for (let gx = 16; gx < this.W; gx += 24) for (let gy = 18; gy < this.H; gy += 24) ctx.fillRect(gx, gy, 1.4, 1.4);
+    ctx.restore();
+  }
+  private pt(ctx: CanvasRenderingContext2D, x: number, y: number, color: string, r?: number): void {
+    r = r || 3.4;
+    ctx.beginPath();
+    ctx.arc(x, y, r, 0, 6.283);
+    ctx.fillStyle = color;
+    ctx.fill();
+    ctx.lineWidth = 0.8;
+    ctx.strokeStyle = 'rgba(255,255,255,0.9)';
+    ctx.stroke();
+  }
+  private arrow(ctx: CanvasRenderingContext2D, x: number, y: number, ang: number, size: number, color: string): void {
+    ctx.save();
+    ctx.fillStyle = color;
+    ctx.translate(x, y);
+    ctx.rotate(ang);
+    ctx.beginPath();
+    ctx.moveTo(0, 0);
+    ctx.lineTo(-size, -size * 0.55);
+    ctx.lineTo(-size, size * 0.55);
+    ctx.closePath();
+    ctx.fill();
+    ctx.restore();
+  }
+  private axis(ctx: CanvasRenderingContext2D, angle: number, alpha: number, accent: string): void {
+    const cx = this.cx;
+    const cy = this.cy;
+    const len = 150;
+    const ex = Math.cos(angle);
+    const ey = Math.sin(angle);
+    ctx.save();
+    ctx.strokeStyle = this.hexA(accent, 0.9 * alpha);
+    ctx.lineWidth = 2.2;
+    ctx.lineCap = 'round';
+    ctx.beginPath();
+    ctx.moveTo(cx - ex * len, cy - ey * len);
+    ctx.lineTo(cx + ex * len, cy + ey * len);
+    ctx.stroke();
+    const col = this.hexA(accent, 0.9 * alpha);
+    this.arrow(ctx, cx + ex * len, cy + ey * len, angle, 7, col);
+    this.arrow(ctx, cx - ex * len, cy - ey * len, angle + Math.PI, 7, col);
+    ctx.restore();
+  }
+  private line(ctx: CanvasRenderingContext2D, a: any, b: any, style: string, w?: number, dash?: number[]): void {
+    ctx.save();
+    if (dash) ctx.setLineDash(dash);
+    ctx.strokeStyle = style;
+    ctx.lineWidth = w || 1;
+    ctx.beginPath();
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  // ---------- per-method draws ----------
+  private draw_pca(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const th = eng.theta;
+    const accent = this.accent;
+    let axisAlpha = 0;
+    let angle = th;
+    let projT = 0;
+    let expandT = 0;
+    let showDrop = false;
+    if (idx === 0) {
+      expandT = this.sm(local / 0.55);
+    } else if (idx === 1) {
+      const sw = this.sm(local);
+      angle = this.lerp(th - 0.85, th, sw);
+      axisAlpha = this.sm(local / 0.3);
+    } else if (idx === 2) {
+      axisAlpha = 1;
+    } else if (idx === 3) {
+      axisAlpha = 1;
+      projT = this.sm(local);
+      showDrop = true;
+    } else {
+      axisAlpha = 1;
+      projT = 1;
+    }
+    const pos = pts.map((p: any) => {
+      if (idx === 0) return { x: this.lerp(p.px, p.bx, expandT), y: this.lerp(p.py, p.by, expandT), c: p.color };
+      if (idx <= 2) return { x: p.bx, y: p.by, c: p.color };
+      return { x: this.lerp(p.bx, p.px, projT), y: this.lerp(p.by, p.py, projT), c: p.color };
+    });
+    if (showDrop) {
+      ctx.save();
+      ctx.setLineDash([2, 3]);
+      ctx.lineWidth = 0.8;
+      ctx.strokeStyle = this.hexA('#5a6672', 0.32 * Math.sin(projT * Math.PI));
+      for (const p of pts) {
+        ctx.beginPath();
+        ctx.moveTo(p.bx, p.by);
+        ctx.lineTo(p.px, p.py);
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+    if (axisAlpha > 0) this.axis(ctx, angle, axisAlpha, accent);
+    for (const p of pos) this.pt(ctx, p.x, p.y, p.c);
+  }
+
+  private draw_fast(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const accent = this.accent;
+    const P = pts[eng.pi];
+    const Q = pts[eng.pj];
+    let pivotA = 0;
+    let axisT = 0;
+    let projT = 0;
+    let expandT = 1;
+    let showDrop = false;
+    if (idx === 0) {
+      expandT = this.sm(local / 0.55);
+    } else if (idx === 1) {
+      pivotA = this.sm(local / 0.5);
+    } else if (idx === 2) {
+      pivotA = 1;
+      axisT = this.sm(local);
+    } else if (idx === 3) {
+      pivotA = 1;
+      axisT = 1;
+      projT = this.sm(local);
+      showDrop = true;
+    } else {
+      pivotA = 0.6;
+      axisT = 1;
+      projT = 1;
+    }
+    const pos = pts.map((p: any) => {
+      if (idx === 0) return { x: this.lerp(p.px, p.bx, expandT), y: this.lerp(p.py, p.by, expandT), c: p.color };
+      if (idx <= 2) return { x: p.bx, y: p.by, c: p.color };
+      return { x: this.lerp(p.bx, p.px, projT), y: this.lerp(p.by, p.py, projT), c: p.color };
+    });
+    if (showDrop) {
+      ctx.save();
+      ctx.setLineDash([2, 3]);
+      ctx.lineWidth = 0.8;
+      ctx.strokeStyle = this.hexA('#5a6672', 0.32 * Math.sin(projT * Math.PI));
+      for (const p of pts) {
+        ctx.beginPath();
+        ctx.moveTo(p.bx, p.by);
+        ctx.lineTo(p.px, p.py);
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+    if (axisT > 0) {
+      const mx = (P.bx + Q.bx) / 2;
+      const my = (P.by + Q.by) / 2;
+      const ex = Math.cos(eng.angle);
+      const ey = Math.sin(eng.angle);
+      const half = (Math.hypot(Q.bx - P.bx, Q.by - P.by) / 2 + 16) * axisT;
+      ctx.save();
+      ctx.strokeStyle = this.hexA(accent, 0.9);
+      ctx.lineWidth = 2.2;
+      ctx.lineCap = 'round';
+      ctx.beginPath();
+      ctx.moveTo(mx - ex * half, my - ey * half);
+      ctx.lineTo(mx + ex * half, my + ey * half);
+      ctx.stroke();
+      if (axisT > 0.95) {
+        const col = this.hexA(accent, 0.9);
+        this.arrow(ctx, mx + ex * half, my + ey * half, eng.angle, 7, col);
+        this.arrow(ctx, mx - ex * half, my - ey * half, eng.angle + Math.PI, 7, col);
+      }
+      ctx.restore();
+    }
+    if (pivotA > 0) {
+      const pulse = idx === 1 ? 1 + 0.18 * Math.sin(this.clock * 6) : 1;
+      ctx.save();
+      for (const pv of [P, Q]) {
+        const x = idx >= 3 ? this.lerp(pv.bx, pv.px, projT) : pv.bx;
+        const y = idx >= 3 ? this.lerp(pv.by, pv.py, projT) : pv.by;
+        ctx.beginPath();
+        ctx.arc(x, y, 9.5 * pulse, 0, 6.283);
+        ctx.strokeStyle = this.hexA(accent, 0.85 * pivotA);
+        ctx.lineWidth = 1.8;
+        ctx.stroke();
+        ctx.beginPath();
+        ctx.arc(x, y, 15 * pulse, 0, 6.283);
+        ctx.strokeStyle = this.hexA(accent, 0.25 * pivotA);
+        ctx.lineWidth = 1.2;
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+    for (let i = 0; i < pts.length; i++) {
+      const big = (i === eng.pi || i === eng.pj) && pivotA > 0;
+      this.pt(ctx, pos[i].x, pos[i].y, pos[i].c, big ? 4.6 : 3.4);
+    }
+  }
+
+  private draw_umap(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const edges = eng.edges;
+    const gc = eng.groupColors;
+    let edgeA = 0;
+    let mix = 0;
+    let pos: any[];
+    if (idx === 0) {
+      const re = this.sm(local / 0.55);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.cx, p.sx, re), y: this.lerp(p.cy, p.sy, re) }));
+      mix = 1 - re;
+    } else if (idx === 1) {
+      pos = pts.map((p: any) => ({ x: p.sx, y: p.sy }));
+      edgeA = this.sm(local);
+      mix = 0;
+    } else if (idx === 2) {
+      const mT = this.sm(local);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.sx, p.cx, mT), y: this.lerp(p.sy, p.cy, mT) }));
+      edgeA = 1;
+      mix = mT;
+    } else {
+      pos = pts.map((p: any) => ({ x: p.cx, y: p.cy }));
+      edgeA = 1;
+      mix = 1;
+    }
+    if (edgeA > 0) {
+      ctx.save();
+      ctx.lineWidth = 1;
+      for (const [i, j] of edges) {
+        ctx.strokeStyle = this.rgba(this.mix('#9aa9b6', gc[pts[i].g], mix), 0.3 * edgeA);
+        ctx.beginPath();
+        ctx.moveTo(pos[i].x, pos[i].y);
+        ctx.lineTo(pos[j].x, pos[j].y);
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+    for (let i = 0; i < pts.length; i++)
+      this.pt(ctx, pos[i].x, pos[i].y, this.rgb(this.mix('#9aa9b6', gc[pts[i].g], mix)));
+  }
+
+  private draw_tsne(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const gc = eng.groupColors;
+    const clock = this.clock;
+    const accent = this.accent;
+    let mix = 0;
+    let halo = 0;
+    let pos: any[];
+    if (idx === 0) {
+      const re = this.sm(local / 0.55);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.cx, p.sx, re), y: this.lerp(p.cy, p.sy, re) }));
+      mix = 1 - re;
+    } else if (idx === 1) {
+      pos = pts.map((p: any) => ({ x: p.sx, y: p.sy }));
+      mix = 0;
+      halo = this.sm(local);
+    } else if (idx === 2) {
+      const mT = this.sm(local);
+      const amp = (1 - mT) * 7;
+      pos = pts.map((p: any) => ({
+        x: this.lerp(p.sx, p.cx, mT) + Math.cos(clock * 5.5 + p.jp) * amp,
+        y: this.lerp(p.sy, p.cy, mT) + Math.sin(clock * 4.7 + p.jp * 1.4) * amp,
+      }));
+      mix = mT;
+      halo = (1 - mT) * 0.5;
+    } else {
+      pos = pts.map((p: any) => ({ x: p.cx, y: p.cy }));
+      mix = 1;
+    }
+    if (halo > 0) {
+      ctx.save();
+      for (const p of pos) {
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, 12, 0, 6.283);
+        ctx.fillStyle = this.hexA(accent, 0.055 * halo);
+        ctx.fill();
+      }
+      ctx.restore();
+    }
+    if (idx === 3) {
+      const a = eng.cent[0];
+      const b = eng.cent[1];
+      ctx.save();
+      ctx.setLineDash([4, 4]);
+      ctx.strokeStyle = 'rgba(120,134,148,0.55)';
+      ctx.lineWidth = 1;
+      ctx.beginPath();
+      ctx.moveTo(a.x, a.y);
+      ctx.lineTo(b.x, b.y);
+      ctx.stroke();
+      ctx.setLineDash([]);
+      const mx = (a.x + b.x) / 2;
+      const my = (a.y + b.y) / 2;
+      ctx.beginPath();
+      ctx.arc(mx, my, 8, 0, 6.283);
+      ctx.fillStyle = '#ffffff';
+      ctx.fill();
+      ctx.strokeStyle = 'rgba(120,134,148,0.6)';
+      ctx.stroke();
+      ctx.fillStyle = '#6b7680';
+      ctx.font = 'italic bold 11px sans-serif';
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'middle';
+      ctx.fillText('?', mx, my + 0.5);
+      ctx.restore();
+    }
+    for (let i = 0; i < pts.length; i++)
+      this.pt(ctx, pos[i].x, pos[i].y, this.rgb(this.mix('#9aa9b6', gc[pts[i].g], mix)));
+  }
+
+  private draw_tri(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const gc = eng.groupColors;
+    const accent = this.accent;
+    let mix = 0;
+    let pos: any[];
+    if (idx === 0) {
+      const re = this.sm(local / 0.55);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.cx, p.sx, re), y: this.lerp(p.cy, p.sy, re) }));
+      mix = 1 - re;
+    } else if (idx === 1) {
+      pos = pts.map((p: any) => ({ x: p.sx, y: p.sy }));
+      mix = 0;
+    } else if (idx === 2) {
+      const mT = this.sm(local);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.sx, p.cx, mT), y: this.lerp(p.sy, p.cy, mT) }));
+      mix = mT;
+    } else {
+      pos = pts.map((p: any) => ({ x: p.cx, y: p.cy }));
+      mix = 1;
+    }
+    if (idx === 1) {
+      const T = eng.triplets.length;
+      const k = Math.min(T - 1, Math.floor(local * T));
+      const frac = local * T - k;
+      const fade = Math.sin(Math.min(1, frac) * Math.PI);
+      const [a, b, c] = eng.triplets[k];
+      this.line(ctx, pos[a], pos[b], this.hexA(accent, 0.85 * fade), 1.8);
+      this.line(ctx, pos[a], pos[c], this.rgba([154, 169, 182], 0.7 * fade), 1.2, [3, 3]);
+      ctx.save();
+      ctx.beginPath();
+      ctx.arc(pos[a].x, pos[a].y, 8.5, 0, 6.283);
+      ctx.strokeStyle = this.hexA(accent, 0.8 * fade);
+      ctx.lineWidth = 1.6;
+      ctx.stroke();
+      ctx.restore();
+    }
+    if (idx === 3) {
+      ctx.save();
+      ctx.setLineDash([4, 4]);
+      ctx.lineWidth = 1;
+      ctx.strokeStyle = 'rgba(120,134,148,0.35)';
+      const c = eng.cent;
+      ctx.beginPath();
+      ctx.moveTo(c[0].x, c[0].y);
+      ctx.lineTo(c[1].x, c[1].y);
+      ctx.lineTo(c[2].x, c[2].y);
+      ctx.closePath();
+      ctx.stroke();
+      ctx.restore();
+    }
+    for (let i = 0; i < pts.length; i++)
+      this.pt(ctx, pos[i].x, pos[i].y, this.rgb(this.mix('#9aa9b6', gc[pts[i].g], mix)));
+  }
+
+  private draw_mds(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const accent = this.accent;
+    let pos: any[];
+    if (idx === 0) {
+      const re = this.sm(local / 0.55);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.px, p.bx, re), y: this.lerp(p.py, p.by, re) }));
+    } else if (idx === 1) {
+      pos = pts.map((p: any) => ({ x: p.bx, y: p.by }));
+    } else if (idx === 2) {
+      const mT = this.sm(local);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.bx, p.px, mT), y: this.lerp(p.by, p.py, mT) }));
+    } else {
+      pos = pts.map((p: any) => ({ x: p.px, y: p.py }));
+    }
+    if (idx === 1) {
+      const A = eng.anchors;
+      const k = Math.min(A.length - 1, Math.floor(local * A.length));
+      const frac = local * A.length - k;
+      const fade = Math.sin(Math.min(1, frac) * Math.PI);
+      const a = A[k];
+      ctx.save();
+      ctx.lineWidth = 0.9;
+      for (let j = 0; j < pts.length; j++) {
+        if (j === a) continue;
+        ctx.strokeStyle = this.hexA(accent, 0.22 * fade);
+        ctx.beginPath();
+        ctx.moveTo(pos[a].x, pos[a].y);
+        ctx.lineTo(pos[j].x, pos[j].y);
+        ctx.stroke();
+      }
+      ctx.beginPath();
+      ctx.arc(pos[a].x, pos[a].y, 8, 0, 6.283);
+      ctx.strokeStyle = this.hexA(accent, 0.85 * fade);
+      ctx.lineWidth = 1.6;
+      ctx.stroke();
+      ctx.restore();
+    }
+    if (idx >= 2) {
+      const ea = idx === 2 ? 0.3 : 0.2;
+      for (const [i, j] of eng.edges) this.line(ctx, pos[i], pos[j], this.rgba([154, 169, 182], ea), 1);
+    }
+    for (let i = 0; i < pts.length; i++) this.pt(ctx, pos[i].x, pos[i].y, pts[i].color);
+  }
+
+  private draw_sammon(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const accent = this.accent;
+    let pos: any[];
+    if (idx === 0) {
+      const re = this.sm(local / 0.55);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.px, p.bx, re), y: this.lerp(p.py, p.by, re) }));
+    } else if (idx === 1) {
+      pos = pts.map((p: any) => ({ x: p.bx, y: p.by }));
+    } else if (idx === 2) {
+      const mT = this.sm(local);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.bx, p.px, mT), y: this.lerp(p.by, p.py, mT) }));
+    } else {
+      pos = pts.map((p: any) => ({ x: p.px, y: p.py }));
+    }
+    if (idx === 1) {
+      const inA = this.sm(local / 0.6);
+      const farA = Math.sin(Math.min(1, local) * Math.PI) * 0.4;
+      for (const [i, j] of eng.far) this.line(ctx, pos[i], pos[j], this.rgba([154, 169, 182], farA), 1, [3, 4]);
+      for (const [i, j] of eng.near) this.line(ctx, pos[i], pos[j], this.hexA(accent, 0.55 * inA), 1.6);
+    }
+    if (idx >= 2) {
+      const ea = idx === 2 ? 0.4 : 0.25;
+      for (const [i, j] of eng.near) this.line(ctx, pos[i], pos[j], this.hexA(accent, ea), 1.3);
+    }
+    for (let i = 0; i < pts.length; i++) this.pt(ctx, pos[i].x, pos[i].y, pts[i].color);
+  }
+
+  private draw_iso(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const n = pts.length;
+    const accent = this.accent;
+    let pos: any[];
+    if (idx === 0) {
+      const re = this.sm(local / 0.55);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.ux, p.bx, re), y: this.lerp(p.uy, p.by, re) }));
+    } else if (idx <= 2) {
+      pos = pts.map((p: any) => ({ x: p.bx, y: p.by }));
+    } else if (idx === 3) {
+      const uT = this.sm(local);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.bx, p.ux, uT), y: this.lerp(p.by, p.uy, uT) }));
+    } else {
+      pos = pts.map((p: any) => ({ x: p.ux, y: p.uy }));
+    }
+    if (idx === 1) {
+      const m = Math.floor(this.sm(local) * (n - 1));
+      for (let i = 0; i < m; i++) this.line(ctx, pos[i], pos[i + 1], this.rgba([154, 169, 182], 0.45), 1.1);
+    }
+    if (idx === 2) {
+      for (let i = 0; i < n - 1; i++) this.line(ctx, pos[i], pos[i + 1], this.rgba([154, 169, 182], 0.3), 1);
+      this.line(ctx, pos[0], pos[n - 1], 'rgba(120,134,148,0.5)', 1, [4, 4]);
+      const m = Math.floor(this.sm(local) * (n - 1));
+      ctx.save();
+      ctx.lineWidth = 2.4;
+      ctx.lineCap = 'round';
+      ctx.strokeStyle = this.hexA(accent, 0.9);
+      ctx.beginPath();
+      ctx.moveTo(pos[0].x, pos[0].y);
+      for (let i = 1; i <= m; i++) ctx.lineTo(pos[i].x, pos[i].y);
+      ctx.stroke();
+      ctx.beginPath();
+      ctx.arc(pos[m].x, pos[m].y, 6, 0, 6.283);
+      ctx.fillStyle = this.hexA(accent, 0.9);
+      ctx.fill();
+      ctx.restore();
+    }
+    if (idx >= 3) {
+      const ea = idx === 3 ? 0.3 : 0.18;
+      for (let i = 0; i < n - 1; i++) this.line(ctx, pos[i], pos[i + 1], this.rgba([154, 169, 182], ea), 1);
+    }
+    for (let i = 0; i < n; i++) this.pt(ctx, pos[i].x, pos[i].y, pts[i].color);
+  }
+
+  private draw_lle(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const n = pts.length;
+    const accent = this.accent;
+    let pos: any[];
+    let webA = 0;
+    if (idx === 0) {
+      const re = this.sm(local / 0.55);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.ux, p.bx, re), y: this.lerp(p.uy, p.by, re) }));
+    } else if (idx === 1) {
+      pos = pts.map((p: any) => ({ x: p.bx, y: p.by }));
+      webA = this.sm(local);
+    } else if (idx === 2) {
+      const uT = this.sm(local);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.bx, p.ux, uT), y: this.lerp(p.by, p.uy, uT) }));
+      webA = 0.8;
+    } else {
+      pos = pts.map((p: any) => ({ x: p.ux, y: p.uy }));
+      webA = 0.5 * (1 - this.sm(local));
+    }
+    if (webA > 0) {
+      ctx.save();
+      for (const s of eng.samples) {
+        for (let dj = -2; dj <= 2; dj++) {
+          const j = s + dj;
+          if (dj === 0 || j < 0 || j >= n) continue;
+          this.line(ctx, pos[s], pos[j], this.hexA(accent, 0.5 * webA), 1.2);
+        }
+        ctx.beginPath();
+        ctx.arc(pos[s].x, pos[s].y, 8, 0, 6.283);
+        ctx.strokeStyle = this.hexA(accent, 0.65 * webA);
+        ctx.lineWidth = 1.4;
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+    for (let i = 0; i < n; i++) this.pt(ctx, pos[i].x, pos[i].y, pts[i].color);
+  }
+
+  private draw_ltsa(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const n = pts.length;
+    const accent = this.accent;
+    let pos: any[];
+    let tanA = 0;
+    let tanLen = 15;
+    if (idx === 0) {
+      const re = this.sm(local / 0.55);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.ux, p.bx, re), y: this.lerp(p.uy, p.by, re) }));
+    } else if (idx === 1) {
+      pos = pts.map((p: any) => ({ x: p.bx, y: p.by }));
+      tanA = 0.85;
+      tanLen = 15 * this.sm(local);
+    } else if (idx === 2) {
+      const uT = this.sm(local);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.bx, p.ux, uT), y: this.lerp(p.by, p.uy, uT) }));
+      tanA = 0.75;
+    } else {
+      pos = pts.map((p: any) => ({ x: p.ux, y: p.uy }));
+      tanA = 0.4 * (1 - this.sm(local));
+    }
+    if (tanA > 0 && tanLen > 0.5) {
+      ctx.save();
+      ctx.lineCap = 'round';
+      for (const s of eng.samples) {
+        const a = pos[Math.max(0, s - 1)];
+        const b = pos[Math.min(n - 1, s + 1)];
+        const ang = Math.atan2(b.y - a.y, b.x - a.x);
+        const ex = Math.cos(ang) * tanLen;
+        const ey = Math.sin(ang) * tanLen;
+        ctx.strokeStyle = this.hexA(accent, tanA);
+        ctx.lineWidth = 2.4;
+        ctx.beginPath();
+        ctx.moveTo(pos[s].x - ex, pos[s].y - ey);
+        ctx.lineTo(pos[s].x + ex, pos[s].y + ey);
+        ctx.stroke();
+      }
+      ctx.restore();
+    }
+    for (let i = 0; i < n; i++) this.pt(ctx, pos[i].x, pos[i].y, pts[i].color);
+  }
+
+  private draw_topo(ctx: CanvasRenderingContext2D, idx: number, local: number, eng: any): void {
+    this.grid(ctx);
+    const pts = eng.pts;
+    const edges = eng.edges;
+    const gc = eng.groupColors;
+    const accent = this.accent;
+    let mix = 0;
+    let pos: any[];
+    let edgeCount = 0;
+    let edgeA = 0;
+    if (idx === 0) {
+      const re = this.sm(local / 0.55);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.cx, p.sx, re), y: this.lerp(p.cy, p.sy, re) }));
+      mix = 1 - re;
+    } else if (idx === 1) {
+      pos = pts.map((p: any) => ({ x: p.sx, y: p.sy }));
+      edgeCount = Math.floor(this.sm(local) * edges.length);
+      edgeA = 0.5;
+    } else if (idx === 2) {
+      const mT = this.sm(local);
+      pos = pts.map((p: any) => ({ x: this.lerp(p.sx, p.cx, mT), y: this.lerp(p.sy, p.cy, mT) }));
+      mix = mT;
+      edgeCount = edges.length;
+      edgeA = 0.45;
+    } else {
+      pos = pts.map((p: any) => ({ x: p.cx, y: p.cy }));
+      mix = 1;
+      edgeCount = edges.length;
+      edgeA = 0.3;
+    }
+    for (let e = 0; e < edgeCount; e++) {
+      const [i, j] = edges[e];
+      this.line(
+        ctx,
+        pos[i],
+        pos[j],
+        idx === 1 ? this.hexA(accent, edgeA) : this.rgba(this.mix('#9aa9b6', '#7e8f9c', mix), edgeA),
+        1.2
+      );
+    }
+    if (idx === 1 && edgeCount > 0 && edgeCount <= edges.length) {
+      const [, j] = edges[Math.min(edgeCount - 1, edges.length - 1)];
+      ctx.save();
+      ctx.beginPath();
+      ctx.arc(pos[j].x, pos[j].y, 7.5, 0, 6.283);
+      ctx.strokeStyle = this.hexA(accent, 0.8);
+      ctx.lineWidth = 1.6;
+      ctx.stroke();
+      ctx.restore();
+    }
+    for (let i = 0; i < pts.length; i++)
+      this.pt(ctx, pos[i].x, pos[i].y, this.rgb(this.mix('#9aa9b6', gc[pts[i].g], mix)));
+  }
+
+  // ---------- loop ----------
+  private phaseOf(caps: CaptionStep[], t: number): { i: number; local: number } {
+    let acc = 0;
+    for (let i = 0; i < caps.length; i++) {
+      if (t < acc + caps[i].d) return { i, local: (t - acc) / caps[i].d };
+      acc += caps[i].d;
+    }
+    return { i: caps.length - 1, local: 1 };
+  }
+
+  private tick = (): void => {
+    this.rafId = null;
+    const canvas = this.canvasRef?.nativeElement;
+    if (!this.isOpen || !canvas || !this.eng) return;
+    const now = performance.now();
+    const dt = Math.min(0.05, (now - (this.last || now)) / 1000);
+    this.last = now;
+    this.clock += dt * this.speed;
+
+    const ctx = canvas.getContext('2d')!;
+    ctx.clearRect(0, 0, this.W, this.H);
+    const total = this.caps.reduce((s, c) => s + c.d, 0);
+    const { i, local } = this.phaseOf(this.caps, this.clock % total);
+    (this as any)['draw_' + this.methodKeyResolved()](ctx, i, local, this.eng);
+
+    if (this.currentPhase !== i) {
+      this.currentPhase = i;
+      this.cdr.detectChanges();
+    }
+    this.rafId = requestAnimationFrame(this.tick);
+  };
+
+  private methodKeyResolved(): string {
+    return this.META[this.methodKey] ? this.methodKey : 'pca';
+  }
+}

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.html
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.html
@@ -109,6 +109,7 @@
                 <div class="card-title-row">
                   <h3 [title]="selectedColumn.column.name">{{ selectedColumn.column.name }}</h3>
                   <span class="type-pill">{{ getTypeLabel(selectedColumn.column.dataType) }}</span>
+                  <app-help-tooltip [helpText]="HELP_TEXT.general.smartDefaults" position="bottom"></app-help-tooltip>
                   @if (isColumnModified(selectedColumn)) {
                     <button
                       class="btn-reset-column"

--- a/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.scss
+++ b/src/app/preprocessing-wizard/steps/step3-configure-data-features/step3-configure-data-features.component.scss
@@ -220,6 +220,9 @@
     // A14: fill the fixed box height and scroll internally when the column config
     // is taller than the box (instead of stretching the whole step downwards).
     min-height: 0;
+    // Only scroll vertically. `overflow-y: auto` alone makes overflow-x compute
+    // to `auto` too, which produced a stray horizontal scrollbar; pin it hidden.
+    overflow-x: hidden;
     overflow-y: auto;
     display: flex;
     flex-direction: column;
@@ -247,7 +250,11 @@
   }
 
   .detail-card {
-    flex: 1;
+    // Grow to fill the well when content is short, but never shrink below the
+    // content's natural height — so tall configurations (e.g. the outlier
+    // principles note) make the card taller and the .detail-well scrolls,
+    // instead of the card clipping its own overflow.
+    flex: 1 0 auto;
     display: flex;
     flex-direction: column;
     background: white;

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.html
@@ -5,7 +5,10 @@
     <div class="config-panel color-feature-panel">
       <div class="panel-header-row">
         <div class="form-group">
-          <label class="menu-label" for="step4-color-attribute">COLOR ATTRIBUTE</label>
+          <label class="menu-label" for="step4-color-attribute">
+            COLOR ATTRIBUTE
+            <app-help-tooltip [helpText]="HELP_TEXT.general.colorFeature"></app-help-tooltip>
+          </label>
           <select id="step4-color-attribute" [ngModel]="colorFeature" (ngModelChange)="setColorFeature($event)">
             @for (column of columns; track column.name) {
               <option [value]="column.name">{{ column.name }}</option>
@@ -14,7 +17,10 @@
         </div>
 
         <div class="form-group">
-          <label class="menu-label" for="step4-color-scale">COLOR SCALE</label>
+          <label class="menu-label" for="step4-color-scale">
+            COLOR SCALE
+            <app-help-tooltip [helpText]="HELP_TEXT.general.colorScale"></app-help-tooltip>
+          </label>
           <app-color-scale-selector
             id="step4-color-scale"
             [groupedColorScales]="groupedColorScales"
@@ -439,7 +445,8 @@
           <div class="primary-badge">
             <span class="material-icons">bolt</span>
             <span>FastMap</span>
-            <span class="speed-badge badge-primary">Primary</span>
+            <span class="speed-badge badge-primary">Always active</span>
+            <app-projection-preview class="method-preview" methodKey="fast" position="bottom"></app-projection-preview>
           </div>
         </div>
 
@@ -487,6 +494,13 @@
                     </span>
                   </button>
                 }
+                <app-projection-preview
+                  class="method-preview"
+                  [methodKey]="getPreviewKey(method)"
+                  position="left"
+                  (click)="$event.stopPropagation()"
+                  (keydown)="$event.stopPropagation()"
+                ></app-projection-preview>
               </div>
               <div class="card-desc">{{ method.description }}</div>
 

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.scss
@@ -593,6 +593,22 @@
           font-size: 13px;
         }
       }
+
+      // Animated method explainer (A1): help icon pinned to the far right of
+      // the card row. Uses auto margin so it stays right whether or not the
+      // parameter-toggle button is present.
+      .method-preview {
+        margin-left: auto;
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+      }
+
+      // When the parameter toggle is also shown, it should sit next to the
+      // preview icon rather than fighting it for the auto margin.
+      .btn-expand-params + .method-preview {
+        margin-left: 4px;
+      }
     }
 
     .speed-badge {

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
@@ -12,6 +12,7 @@ import {
   getScalingLabel as scalingLabelFn,
 } from '../../models/data-type.enum';
 import { HelpTooltipComponent } from '../../shared/help-tooltip/help-tooltip.component';
+import { ProjectionPreviewComponent } from '../../shared/projection-preview/projection-preview.component';
 import { HELP_TEXT } from '../../shared/constants/help-text';
 import { STEP_INFO } from '../../shared/constants/step-info';
 import { DataTypeBadgeComponent } from '../../shared/data-type-badge/data-type-badge.component';
@@ -68,7 +69,14 @@ interface ProjectionMethodUI {
 @Component({
   selector: 'app-step4-visualization-settings',
   standalone: true,
-  imports: [CommonModule, FormsModule, HelpTooltipComponent, DataTypeBadgeComponent, ColorScaleSelectorComponent],
+  imports: [
+    CommonModule,
+    FormsModule,
+    HelpTooltipComponent,
+    ProjectionPreviewComponent,
+    DataTypeBadgeComponent,
+    ColorScaleSelectorComponent,
+  ],
   templateUrl: './step4-visualization-settings.component.html',
   styleUrl: './step4-visualization-settings.component.scss',
   providers: [{ provide: WIZARD_STEP, useExisting: forwardRef(() => Step4VisualizationSettingsComponent) }],
@@ -146,6 +154,25 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
 
   readonly TSNE_WARNING_THRESHOLD = 5000;
   readonly LARGE_DATASET_THRESHOLD = 10000;
+
+  /** Maps a projection method's config key to its animated-preview key. */
+  private readonly previewKeys: Record<string, string> = {
+    enablePCA: 'pca',
+    enableTriMap: 'tri',
+    enableMDS: 'mds',
+    enableIsoMap: 'iso',
+    enableLLE: 'lle',
+    enableLTSA: 'ltsa',
+    enableTopoMap: 'topo',
+    enableUMAP: 'umap',
+    enableSammon: 'sammon',
+    enableTSNE: 'tsne',
+  };
+
+  /** Preview key for a method's animated explainer tooltip. */
+  getPreviewKey(method: ProjectionMethodUI): string {
+    return this.previewKeys[method.key] ?? 'pca';
+  }
 
   // Sorted by speed (fastest first)
   projectionMethods: ProjectionMethodUI[] = [


### PR DESCRIPTION
Setzt **A1 (Erklärungen)** und **A11 (technische Defekte)** gemeinsam um. Zwei gruppierte Commits.

## A1 – Fachbegriffe und Optionen erklären
- **Neue Komponente `shared/projection-preview/`**: animierte Canvas-Vorschau je Projektionsmethode (portiert aus der ClaudeDesign-Vorlage „Projection Previews"). Baut/animiert nur die angefragte Methode und läuft nur, solange das Popup offen ist. Tempo 0.5.
- **Step 4**: Jede Projektionskarte und FastMap erhalten ein Hilfe-Icon mit Vorschau-Popup (Hover öffnet, Klick pinnt). FastMap-Badge „Primary" → „Always active".
- **Step 4**: Erklärtexte für Farbattribut (`colorFeature`) und Farbskala (`colorScale`) eingebunden; im Farbskala-Text steht, dass sie rein kosmetisch ist (nur Einfärbung, nicht Projektion/Daten — verifiziert).
- **Step 3**: Smart-Defaults-Erklärtext an der Spalten-Konfigurationskarte.
- Outlier-Tooltip kompakt um die zwei Prinzipien (IQR vs. Z-Score) und den Strenge-Hinweis ergänzt (erklärt, warum „Moderate"/„Relaxed" bei beiden auftauchen — deckt C-S3-04 ab).

## A11 – Technische Defekte
- **C-S4-04**: Tooltip bleibt beim Hineinfahren offen (Grace-Period) — Voraussetzung, um Vorschau/Text zu lesen.
- Hilfe-Icon nicht mehr dauerhaft blau nach Klick (Farbe nur bei Hover / `:focus-visible`).
- **Tooltip-Platzierung Step 3**: `gsap.from()` (A14-Morph) hinterließ ein inline `transform` auf `.detail-well`, wodurch `position:fixed`-Tooltips relativ zur Welle statt zum Viewport rechneten; `clearProps: 'transform'` entfernt es nach der Animation.
- Keine horizontale Scrollbar mehr: Tooltips bis zur Positionsberechnung außerhalb des Sichtfelds geparkt, Clamping an `clientWidth/Height`; `.detail-well` `overflow-x: hidden`.
- `.detail-card` wächst mit dem Inhalt (`flex: 1 0 auto`) — kein Abschneiden langer Konfiguration mehr.

Bereits behoben/verifiziert (keine Änderung nötig): S-S3-03 (Tooltip-Z-Ebene), S-S4-02 (Rücksprung Step 4), P-S5-02/03 (über A3).

## Manuelle Testschritte
1. **Vorschau-Animation** → Step 4, Hilfe-Icon einer Projektionskarte hovern → Popup mit laufender Animation + Caption; Maus ins Popup fahren → bleibt offen.
2. **FastMap** → Step 4, Icon am FastMap-Badge → Popup zeigt „Always active" + Animation.
3. **Farb-Erklärungen** → Step 4, Icons an COLOR ATTRIBUTE und COLOR SCALE → Tooltips; beide Dropdowns auf einer Linie.
4. **Fokus-Zustand** → Step 4/3, Icon anklicken, Maus wegbewegen → Icon wieder grau (nicht dauerhaft blau).
5. **Outlier-Erklärung** → Step 3, numerische Spalte, Icon an OUTLIERS → kompakter Tooltip zu IQR/Z-Score + Strenge-Hinweis.
6. **Smart Defaults** → Step 3, Spalte wählen, Icon in der Konfigurationskarte → Erklärtext.
7. **Tooltip-Platzierung/Scrollbar** → Step 3 (über den 2→3-Morph erreichen), alle (?) hovern → Tooltip erscheint am Icon (nicht in der Ecke), keine horizontale Scrollbar.
8. **Kein Abschneiden** → Step 3, Spalte mit vielen Optionen → Konfiguration scrollt sauber, nichts abgeschnitten.
