### PR TITLE
feat(a2): Smart Defaults erweitern (A2-Nachtrag) - Hochkardinalitaet Schritt 2 + colorFeature

### DIFF
--- a/src/app/preprocessing-wizard/services/preprocessing.service.spec.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.spec.ts
@@ -322,7 +322,9 @@ describe('PreprocessingService – Undo/Redo history', () => {
     function mutateColumn<K extends keyof ColumnConfig>(field: K, value: ColumnConfig[K]): void {
       const configs = new Map(service.currentState.columnConfigs);
       configs.set('alpha', { ...configs.get('alpha')!, [field]: value });
-      (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({ columnConfigs: configs });
+      (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({
+        columnConfigs: configs,
+      });
     }
 
     function setTop(updates: Partial<PreprocessingState>): void {
@@ -330,22 +332,118 @@ describe('PreprocessingService – Undo/Redo history', () => {
     }
 
     const cases: { name: string; mutate: () => void; label: string; step: number | null; anchor: string | null }[] = [
-      { name: 'rawFileName', mutate: () => setTop({ rawFileName: 'anders.csv' }), label: 'Datei', step: 0, anchor: null },
-      { name: 'datasetName', mutate: () => setTop({ datasetName: 'umbenannt' }), label: 'Datensatzname', step: 0, anchor: null },
-      { name: 'columnConfigs.enabled', mutate: () => mutateColumn('enabled', false), label: 'Spaltenauswahl', step: 1, anchor: 'wizard-anchor-columns' },
-      { name: 'columnConfigs.isColorFeature', mutate: () => mutateColumn('isColorFeature', true), label: 'Farbattribut', step: 3, anchor: 'wizard-anchor-color' },
-      { name: 'columnConfigs.targetType', mutate: () => mutateColumn('targetType', DataType.Categorical), label: 'Datentyp', step: 2, anchor: 'wizard-anchor-features' },
-      { name: 'columnConfigs.encodingMethod', mutate: () => mutateColumn('encodingMethod', EncodingMethod.Standardize), label: 'Encoding', step: 2, anchor: 'wizard-anchor-features' },
-      { name: 'columnConfigs.scalingMethod', mutate: () => mutateColumn('scalingMethod', ScalingMethod.Standard), label: 'Skalierung', step: 2, anchor: 'wizard-anchor-features' },
-      { name: 'columnConfigs.includeInProjection', mutate: () => mutateColumn('includeInProjection', false), label: 'Projektionsspalten', step: 3, anchor: 'wizard-anchor-projection-columns' },
-      { name: 'columnConfigs.missingValueStrategy', mutate: () => mutateColumn('missingValueStrategy', MissingValueStrategy.FillMean), label: 'Fehlende Werte', step: 2, anchor: 'wizard-anchor-features' },
-      { name: 'columnConfigs.outlierStrategy', mutate: () => mutateColumn('outlierStrategy', OutlierStrategy.Remove), label: 'Ausreißerbehandlung', step: 2, anchor: 'wizard-anchor-features' },
-      { name: 'cleaningConfig', mutate: () => setTop({ cleaningConfig: { removeDuplicates: true } }), label: 'Datenbereinigung', step: 2, anchor: 'wizard-anchor-cleaning' },
-      { name: 'projectionConfig', mutate: () => setTop({ projectionConfig: { ...service.currentState.projectionConfig, enablePCA: false } }), label: 'Projektionsparameter', step: 3, anchor: 'wizard-anchor-methods' },
-      { name: 'glyphFeatures', mutate: () => setTop({ glyphFeatures: ['alpha'] }), label: 'Glyph-Merkmale', step: 3, anchor: 'wizard-anchor-glyph' },
-      { name: 'tooltipFeatures', mutate: () => setTop({ tooltipFeatures: ['alpha'] }), label: 'Tooltip-Merkmale', step: 3, anchor: 'wizard-anchor-glyph' },
-      { name: 'colorScaleMode', mutate: () => setTop({ colorScaleMode: 'categorical' }), label: 'Farbmodus', step: 3, anchor: 'wizard-anchor-color' },
-      { name: 'colorScaleId', mutate: () => setTop({ colorScaleId: 5 }), label: 'Farbskala', step: 3, anchor: 'wizard-anchor-color' },
+      {
+        name: 'rawFileName',
+        mutate: () => setTop({ rawFileName: 'anders.csv' }),
+        label: 'Datei',
+        step: 0,
+        anchor: null,
+      },
+      {
+        name: 'datasetName',
+        mutate: () => setTop({ datasetName: 'umbenannt' }),
+        label: 'Datensatzname',
+        step: 0,
+        anchor: null,
+      },
+      {
+        name: 'columnConfigs.enabled',
+        mutate: () => mutateColumn('enabled', false),
+        label: 'Spaltenauswahl',
+        step: 1,
+        anchor: 'wizard-anchor-columns',
+      },
+      {
+        name: 'columnConfigs.isColorFeature',
+        mutate: () => mutateColumn('isColorFeature', true),
+        label: 'Farbattribut',
+        step: 3,
+        anchor: 'wizard-anchor-color',
+      },
+      {
+        name: 'columnConfigs.targetType',
+        mutate: () => mutateColumn('targetType', DataType.Categorical),
+        label: 'Datentyp',
+        step: 2,
+        anchor: 'wizard-anchor-features',
+      },
+      {
+        name: 'columnConfigs.encodingMethod',
+        mutate: () => mutateColumn('encodingMethod', EncodingMethod.Standardize),
+        label: 'Encoding',
+        step: 2,
+        anchor: 'wizard-anchor-features',
+      },
+      {
+        name: 'columnConfigs.scalingMethod',
+        mutate: () => mutateColumn('scalingMethod', ScalingMethod.Standard),
+        label: 'Skalierung',
+        step: 2,
+        anchor: 'wizard-anchor-features',
+      },
+      {
+        name: 'columnConfigs.includeInProjection',
+        mutate: () => mutateColumn('includeInProjection', false),
+        label: 'Projektionsspalten',
+        step: 3,
+        anchor: 'wizard-anchor-projection-columns',
+      },
+      {
+        name: 'columnConfigs.missingValueStrategy',
+        mutate: () => mutateColumn('missingValueStrategy', MissingValueStrategy.FillMean),
+        label: 'Fehlende Werte',
+        step: 2,
+        anchor: 'wizard-anchor-features',
+      },
+      {
+        name: 'columnConfigs.outlierStrategy',
+        mutate: () => mutateColumn('outlierStrategy', OutlierStrategy.Remove),
+        label: 'Ausreißerbehandlung',
+        step: 2,
+        anchor: 'wizard-anchor-features',
+      },
+      {
+        name: 'cleaningConfig',
+        mutate: () => setTop({ cleaningConfig: { removeDuplicates: true } }),
+        label: 'Datenbereinigung',
+        step: 2,
+        anchor: 'wizard-anchor-cleaning',
+      },
+      {
+        name: 'projectionConfig',
+        mutate: () => setTop({ projectionConfig: { ...service.currentState.projectionConfig, enablePCA: false } }),
+        label: 'Projektionsparameter',
+        step: 3,
+        anchor: 'wizard-anchor-methods',
+      },
+      {
+        name: 'glyphFeatures',
+        mutate: () => setTop({ glyphFeatures: ['alpha'] }),
+        label: 'Glyph-Merkmale',
+        step: 3,
+        anchor: 'wizard-anchor-glyph',
+      },
+      {
+        name: 'tooltipFeatures',
+        mutate: () => setTop({ tooltipFeatures: ['alpha'] }),
+        label: 'Tooltip-Merkmale',
+        step: 3,
+        anchor: 'wizard-anchor-glyph',
+      },
+      {
+        name: 'colorScaleMode',
+        mutate: () => setTop({ colorScaleMode: 'categorical' }),
+        label: 'Farbmodus',
+        step: 3,
+        anchor: 'wizard-anchor-color',
+      },
+      {
+        name: 'colorScaleId',
+        mutate: () => setTop({ colorScaleId: 5 }),
+        label: 'Farbskala',
+        step: 3,
+        anchor: 'wizard-anchor-color',
+      },
     ];
 
     cases.forEach(c => {
@@ -361,7 +459,9 @@ describe('PreprocessingService – Undo/Redo history', () => {
       service.pushHistory('irgendeine Aktion');
       const configs = new Map(service.currentState.columnConfigs);
       configs.delete('gamma');
-      (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({ columnConfigs: configs });
+      (service as unknown as { updateState(u: Partial<PreprocessingState>): void }).updateState({
+        columnConfigs: configs,
+      });
       const info = service.undo()!;
       expect(info.settingLabel).toBe('Spaltenauswahl');
     });
@@ -429,7 +529,9 @@ describe('PreprocessingService – Undo/Redo history', () => {
     };
 
     function serviceWithLoader() {
-      const proc = { profileData: async () => profile } as unknown as ConstructorParameters<typeof PreprocessingService>[0];
+      const proc = { profileData: async () => profile } as unknown as ConstructorParameters<
+        typeof PreprocessingService
+      >[0];
       return new PreprocessingService(proc, dataLoaderStub);
     }
 
@@ -531,5 +633,86 @@ describe('PreprocessingService — error handling (A3)', () => {
       // No error present → no extra state emission.
       expect(emissions).toBe(before);
     });
+  });
+});
+
+/**
+ * A2-Nachtrag – smart defaults for the initial column selection.
+ *
+ * createDefaultColumnConfig is private and only reached via loadCSV (worker), so
+ * these tests call it directly through a cast to pin the auto-deselect heuristic:
+ * mostly-missing / constant columns, and the new high-cardinality rule for
+ * text/categorical/ID columns whose values are nearly all unique.
+ */
+describe('PreprocessingService – smart-default column selection', () => {
+  let service: PreprocessingService;
+
+  const dataProcessorStub = {} as unknown as ConstructorParameters<typeof PreprocessingService>[0];
+  const dataLoaderStub = {
+    getDataSetNames: () => [] as string[],
+  } as unknown as ConstructorParameters<typeof PreprocessingService>[1];
+
+  function col(overrides: Partial<ColumnStatistics>): ColumnStatistics {
+    return {
+      name: 'c',
+      dataType: DataType.Categorical,
+      count: 100,
+      missingCount: 0,
+      missingPercentage: 0,
+      uniqueCount: 5,
+      ...overrides,
+    };
+  }
+
+  function defaultConfig(c: ColumnStatistics): ColumnConfig {
+    return (
+      service as unknown as { createDefaultColumnConfig(c: ColumnStatistics): ColumnConfig }
+    ).createDefaultColumnConfig(c);
+  }
+
+  beforeEach(() => {
+    service = new PreprocessingService(dataProcessorStub, dataLoaderStub);
+  });
+
+  it('deselects a nearly all-unique text column (likely ID/free text)', () => {
+    const config = defaultConfig(col({ dataType: DataType.Text, count: 100, uniqueCount: 100 }));
+    expect(config.enabled).toBeFalse();
+    expect(config.hasIssues).toBeFalse(); // high cardinality is not a data-quality issue
+    expect(config.issueDescription).toContain('unique');
+  });
+
+  it('deselects a high-cardinality categorical column at the 90% threshold', () => {
+    const config = defaultConfig(col({ dataType: DataType.Categorical, count: 100, uniqueCount: 95 }));
+    expect(config.enabled).toBeFalse();
+  });
+
+  it('keeps a low-cardinality categorical column', () => {
+    const config = defaultConfig(col({ dataType: DataType.Categorical, count: 100, uniqueCount: 5 }));
+    expect(config.enabled).toBeTrue();
+    expect(config.issueDescription).toBeUndefined();
+  });
+
+  it('does not treat a near-unique numeric column as high cardinality', () => {
+    const config = defaultConfig(col({ dataType: DataType.Numeric, count: 100, uniqueCount: 100 }));
+    expect(config.enabled).toBeTrue();
+    expect(config.issueDescription).toBeUndefined();
+  });
+
+  it('ignores high uniqueness on tiny datasets (below the min-row guard)', () => {
+    const config = defaultConfig(col({ dataType: DataType.Text, count: 15, uniqueCount: 15 }));
+    expect(config.enabled).toBeTrue();
+  });
+
+  it('deselects a mostly-empty column and flags it as a quality issue', () => {
+    const config = defaultConfig(col({ missingPercentage: 80, uniqueCount: 5 }));
+    expect(config.enabled).toBeFalse();
+    expect(config.hasIssues).toBeTrue();
+    expect(config.issueDescription).toContain('missing');
+  });
+
+  it('deselects a constant column', () => {
+    const config = defaultConfig(col({ uniqueCount: 1 }));
+    expect(config.enabled).toBeFalse();
+    expect(config.hasIssues).toBeTrue();
   });
 });

--- a/src/app/preprocessing-wizard/services/preprocessing.service.ts
+++ b/src/app/preprocessing-wizard/services/preprocessing.service.ts
@@ -83,7 +83,11 @@ const SETTING_META: Record<string, SettingMeta> = {
   'columnConfigs.outlierStrategy': { label: 'Ausreißerbehandlung', step: 2, anchorId: 'wizard-anchor-features' },
   cleaningConfig: { label: 'Datenbereinigung', step: 2, anchorId: 'wizard-anchor-cleaning' },
   // Step 4 – Visualisierung (color / glyph / projection live here)
-  'columnConfigs.includeInProjection': { label: 'Projektionsspalten', step: 3, anchorId: 'wizard-anchor-projection-columns' },
+  'columnConfigs.includeInProjection': {
+    label: 'Projektionsspalten',
+    step: 3,
+    anchorId: 'wizard-anchor-projection-columns',
+  },
   'columnConfigs.isColorFeature': { label: 'Farbattribut', step: 3, anchorId: 'wizard-anchor-color' },
   isColorFeature: { label: 'Farbattribut', step: 3, anchorId: 'wizard-anchor-color' },
   colorScaleId: { label: 'Farbskala', step: 3, anchorId: 'wizard-anchor-color' },
@@ -275,12 +279,48 @@ export class PreprocessingService {
     }
   }
 
+  private static readonly HIGH_CARDINALITY_RATIO = 0.9;
+  private static readonly HIGH_CARDINALITY_MIN_ROWS = 20;
+
+  /**
+   * A text/categorical/ID column counts as high-cardinality when nearly all of
+   * its values are unique (typical of IDs, titles or free text). Such columns
+   * carry little structure for a projection and would explode one-hot encoding,
+   * so they start deselected as a smart default. Numeric/date columns are exempt —
+   * near-unique values there are legitimate measurements.
+   */
+  private isHighCardinality(col: ColumnStatistics): boolean {
+    const eligible =
+      col.dataType === DataType.Text || col.dataType === DataType.Categorical || col.dataType === DataType.ID;
+    if (!eligible || col.count <= PreprocessingService.HIGH_CARDINALITY_MIN_ROWS) {
+      return false;
+    }
+    return col.uniqueCount / col.count >= PreprocessingService.HIGH_CARDINALITY_RATIO;
+  }
+
   private createDefaultColumnConfig(col: ColumnStatistics): ColumnConfig {
     const capabilities = DATA_TYPE_CONFIG[col.dataType] ?? DATA_TYPE_CONFIG[DataType.Unknown];
 
-    // Smart default: obviously unsuitable columns (mostly missing or constant)
-    // start deselected. Users can re-enable them in Step 2 at any time.
-    const hasIssues = col.missingPercentage > 50 || col.uniqueCount === 1;
+    // Smart defaults: obviously unsuitable columns start deselected; users can
+    // re-enable them in Step 2 at any time. issueDescription records WHY a column
+    // was auto-deselected so Step 2 can show a reason next to it.
+    const isMostlyMissing = col.missingPercentage > 50;
+    const isConstant = col.uniqueCount === 1;
+    const isHighCardinality = this.isHighCardinality(col);
+
+    // hasIssues drives the data-quality warning icon (mostly-missing / constant).
+    const hasIssues = isMostlyMissing || isConstant;
+    const autoDeselected = hasIssues || isHighCardinality;
+
+    let issueDescription: string | undefined;
+    if (isMostlyMissing) {
+      issueDescription = `Mostly empty (${Math.round(col.missingPercentage)}% missing)`;
+    } else if (isConstant) {
+      issueDescription = 'Only one unique value — nothing to distinguish rows';
+    } else if (isHighCardinality) {
+      const pct = Math.round((col.uniqueCount / col.count) * 100);
+      issueDescription = `Nearly all values are unique (${pct}%) — likely an ID, title or free-text column`;
+    }
 
     return {
       name: col.name,
@@ -293,8 +333,9 @@ export class PreprocessingService {
       missingValueStrategy: MissingValueStrategy.Keep,
       outlierMethod: OutlierMethod.IQR_1_5,
       outlierStrategy: OutlierStrategy.Keep,
-      enabled: !hasIssues,
+      enabled: !autoDeselected,
       hasIssues,
+      issueDescription,
     };
   }
 

--- a/src/app/preprocessing-wizard/shared/constants/help-text.ts
+++ b/src/app/preprocessing-wizard/shared/constants/help-text.ts
@@ -417,7 +417,7 @@ export const HELP_TEXT = {
     colorFeature: `<strong>Color Feature</strong> determines the color of each glyph in the visualization.<br/><br/>
       • <strong>Numeric:</strong> Creates a continuous color gradient (e.g., blue to red)<br/>
       • <strong>Categorical:</strong> Assigns distinct colors to each category<br/><br/>
-      <em>Optional - leave unselected for uniform color across all glyphs</em>`,
+      A sensible attribute is selected automatically (a small categorical group, or the most varied numeric column) — change it anytime.`,
 
     colorScale: `<strong>Color Scale</strong> is the palette used to map the color feature onto the glyphs.<br/><br/>
       It is <strong>purely cosmetic</strong> — it only changes how the visualization looks, not the underlying data or the projection.<br/><br/>

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.html
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.html
@@ -4,8 +4,9 @@
     <div class="info-box">
       <span class="material-icons">info</span>
       <div>
-        <strong>Tip:</strong> Start by deselecting ID columns and text fields unless needed for tooltips. You can search
-        by column name or type (e.g., "numeric").
+        <strong>Tip:</strong> Columns that are nearly all unique (IDs, titles, free text) or mostly empty are
+        <em>deselected automatically</em> — re-enable any of them if you need it. You can search by column name or type
+        (e.g., "numeric").
       </div>
     </div>
 
@@ -127,6 +128,11 @@
                     <span class="name-text" [title]="column.name">{{ column.name }}</span>
                     @if (hasIssues(column)) {
                       <span class="material-icons issue-icon" title="Quality issues detected">warning</span>
+                    }
+                    @if (isAutoDeselected(column.name)) {
+                      <span class="auto-deselected-badge" [title]="getDeselectReason(column.name)"
+                        >Auto-deselected</span
+                      >
                     }
                   </div>
                 </td>

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.scss
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.scss
@@ -183,6 +183,22 @@
     font-size: 16px;
     color: v.$status-warning;
   }
+
+  // Smart-default marker: explains that a column was deselected automatically
+  // (reason in the title tooltip). Distinct from the quality warning icon.
+  .auto-deselected-badge {
+    flex-shrink: 0;
+    font-size: 10px;
+    font-weight: 600;
+    line-height: 1;
+    padding: 2px 6px;
+    border-radius: 4px;
+    color: v.$gray-600;
+    background: v.$gray-100;
+    border: 1px solid v.$gray-300;
+    cursor: help;
+    white-space: nowrap;
+  }
 }
 
 .data-type-badge {

--- a/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.ts
+++ b/src/app/preprocessing-wizard/steps/step2-column-selection/step2-column-selection.component.ts
@@ -202,6 +202,20 @@ export class Step2ColumnSelectionComponent implements OnInit, AfterViewInit, Wiz
   }
 
   /**
+   * True when a column was auto-deselected by a smart default (mostly missing,
+   * constant, or nearly all-unique) and has not been re-enabled by the user.
+   */
+  isAutoDeselected(columnName: string): boolean {
+    const config = this.columnConfigs.get(columnName);
+    return !!config && !config.enabled && !!config.issueDescription;
+  }
+
+  /** Human-readable reason a column was auto-deselected (for the marker tooltip). */
+  getDeselectReason(columnName: string): string {
+    return this.columnConfigs.get(columnName)?.issueDescription ?? '';
+  }
+
+  /**
    * Get unique value percentage
    */
   getUniquePercent(column: ColumnStatistics): string {

--- a/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
+++ b/src/app/preprocessing-wizard/steps/step4-visualization-settings/step4-visualization-settings.component.ts
@@ -387,11 +387,14 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
     const colorCol = Array.from(state.columnConfigs.values()).find(c => c.isColorFeature);
     if (colorCol) {
       this.colorFeature = colorCol.name;
-    } else if (this.columns.length > 0) {
-      this.colorFeature = this.columns[0].name;
-      this.preprocessingService.setColorFeature(this.columns[0].name);
     } else {
-      this.colorFeature = null;
+      // Smart default: pick a meaningful colour attribute instead of just the
+      // first column (see pickDefaultColorFeature).
+      const pick = this.pickDefaultColorFeature();
+      this.colorFeature = pick;
+      if (pick) {
+        this.preprocessingService.setColorFeature(pick);
+      }
     }
     this.selectedColorScaleId = state.colorScaleId;
     this.groupedColorScales = buildGroupedColorScales();
@@ -432,6 +435,35 @@ export class Step4VisualizationSettingsComponent implements OnInit, AfterViewIni
     this.preprocessingService.setColorFeature(columnName);
     // Sync selected scale ID after service auto-switches on type mismatch
     this.selectedColorScaleId = this.preprocessingService.currentState.colorScaleId;
+  }
+
+  /**
+   * Smart default for the colour attribute. Prefers a low-cardinality
+   * categorical/boolean column (distinct, legible colour groups), then falls
+   * back to the numeric column with the most spread (a meaningful gradient),
+   * and only as a last resort to the first column. Returns null if there are
+   * no columns.
+   */
+  private pickDefaultColorFeature(): string | null {
+    if (this.columns.length === 0) return null;
+
+    const lowCardCategorical = this.columns
+      .filter(
+        c =>
+          (c.dataType === DataType.Categorical || c.dataType === DataType.Boolean) &&
+          c.uniqueCount >= 2 &&
+          c.uniqueCount <= 12
+      )
+      .sort((a, b) => a.uniqueCount - b.uniqueCount)[0];
+    if (lowCardCategorical) return lowCardCategorical.name;
+
+    const variance = (c: ColumnStatistics): number => c.variance ?? (c.stdDev ?? 0) ** 2;
+    const numericBySpread = this.columns
+      .filter(c => c.dataType === DataType.Numeric && variance(c) > 0)
+      .sort((a, b) => variance(b) - variance(a))[0];
+    if (numericBySpread) return numericBySpread.name;
+
+    return this.columns[0].name;
   }
 
   getSelectedColorScale(): ColorScale {


### PR DESCRIPTION
Setzt den **A2-Nachtrag** aus der ROADMAP um (Ticket A2, Abschnitt „Nachtrag (TODO) — Smart Defaults erweitern"). Umfang **Hoch + Mittel**.

## Was

**Hoch — Hochkardinalität in Schritt 2**
- Neue Heuristik `isHighCardinality` in `services/preprocessing.service.ts`: Text/Categorical/ID-Spalten mit `uniqueCount/count >= 0.9` **und** `count > 20` starten abgewählt. Numeric/Date ausgenommen (near-unique ist dort legitim).
- `createDefaultColumnConfig` setzt `enabled` und eine `issueDescription` (Grund der Abwahl). `hasIssues` bleibt auf Datenqualität (mostly-missing / konstant) beschränkt.

**Hoch — sichtbare Kennzeichnung (Schritt 2)**
- Expliziter Marker „Auto-deselected" mit Begründung als Tooltip, getrennt vom Qualitäts-Warnicon (`step2-column-selection`).
- Tipp-Text erweitert um den Fall 100 % einzigartiger Werte und den Hinweis auf Reaktivierbarkeit.

**Mittel — klügerer colorFeature-Default (Schritt 4)**
- `pickDefaultColorFeature`: bevorzugt ein niedrig-kardinales Kategorie-/Boolean-Merkmal, sonst die varianzstärkste Numeric, erst zuletzt `columns[0]`. Hinweis dazu im `colorFeature`-Erklärtext.

## Tests
- 7 neue Unit-Tests für die Auto-Deselect-Heuristik (`preprocessing.service.spec.ts`). Gesamt **157/157 grün**, Build ok (nur vorbestehende Bundle-Budget-Warnung).

## Manuelle Testschritte
1. CSV mit ID-/Titel-/Freitextspalte laden → Schritt 2: diese Spalten sind abgewählt und tragen den „Auto-deselected"-Marker (Tooltip nennt den Grund).
2. Schritt 2: numerische Spalte mit vielen Werten bleibt aktiv (nicht als hochkardinal behandelt).
3. Kleiner Datensatz (< ~20 Zeilen) → keine Auto-Abwahl wegen Uniqueness.
4. Schritt 4: COLOR ATTRIBUTE ist mit einem sinnvollen Merkmal vorbelegt (kleine Kategorie bzw. varianzstarke Numeric), nicht zwingend die erste Spalte.
