### PR TITLE
fix(wizard): translate step5 status text to English, dedupe K7 column list

### DIFF
--- a/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.spec.ts
+++ b/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.spec.ts
@@ -134,6 +134,20 @@ describe('classifyProcessingError', () => {
     expectActionable(issue, raw);
   });
 
+  it('K7 collapses a repeated column mention instead of double-counting it', () => {
+    // Simulates a chained Python exception whose formatted traceback repeats the
+    // same "'col' (N distinct values)" fragment (original exception + wrapper).
+    const raw =
+      "These columns have too many distinct values to one-hot encode: 'show_id' (9000 distinct values). " +
+      'During handling of the above exception, another exception occurred: Failed to process data: These ' +
+      "columns have too many distinct values to one-hot encode: 'show_id' (9000 distinct values).";
+    const issue = classifyProcessingError(raw);
+    expect(issue.code).toBe('K7');
+    expect(issue.title).toBe('The column show_id (9000) has too many distinct values');
+    expect(issue.why).not.toMatch(/show_id.*show_id/s);
+    expectActionable(issue, raw);
+  });
+
   it('falls back to a generic, still-actionable blocking issue for unmatched errors', () => {
     const raw = 'Segfault 0xDEADBEEF in libfoo.so at frame #7';
     const issue = classifyProcessingError(raw);

--- a/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.ts
+++ b/src/app/preprocessing-wizard/shared/constants/wizard-error-classes.ts
@@ -132,7 +132,10 @@ export function classifyProcessingError(raw: string): WizardIssue {
     // but the specific cause (a near-unique column blown up by one-hot) has a
     // much more actionable fix than the generic "resource limit" advice.
     issue = template('K7');
-    const pairs = [...raw.matchAll(/'([^']+)' \((\d+) distinct values\)/g)].map(m => `${m[1]} (${m[2]})`);
+    // Deduplicated: a chained/re-raised Python exception can repeat the same
+    // "'col' (N distinct values)" fragment in its formatted traceback, which
+    // would otherwise double-count and re-list the same column.
+    const pairs = [...new Set([...raw.matchAll(/'([^']+)' \((\d+) distinct values\)/g)].map(m => `${m[1]} (${m[2]})`))];
     if (pairs.length === 1) {
       issue.title = `The column ${pairs[0]} has too many distinct values`;
       issue.why = `This column has almost as many different values as there are rows (typical of an ID, title, name or free-text field): ${pairs[0]}. Encoding it would expand the data into that many columns — more than the in-browser engine can hold in memory.`;

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.html
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.html
@@ -218,7 +218,7 @@
             <span class="material-icons">error_outline</span>
             <div>
               <h3>We couldn't finish your visualization — but this is fixable.</h3>
-              <p>Deine hochgeladenen Daten und alle Einstellungen sind noch da — nichts ging verloren.</p>
+              <p>Your uploaded data and all settings are still there — nothing was lost.</p>
             </div>
           </div>
 

--- a/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.ts
+++ b/src/app/preprocessing-wizard/steps/step5-review-processing/step5-review-processing.component.ts
@@ -598,7 +598,7 @@ export class Step5ReviewProcessingComponent implements OnInit, OnDestroy {
    * clearly sees the spinner + progress + method status while it re-runs.
    */
   retryProcessing(): void {
-    this.toastService.info('Verarbeitung wird erneut gestartet…', 3000);
+    this.toastService.info('Restarting processing…', 3000);
     // Make the processing state visible immediately, even before startProcessing's
     // own reset runs, so the transition is never just a flicker.
     this.showProcessing = true;

--- a/src/assets/preprocessing_processor_config.py
+++ b/src/assets/preprocessing_processor_config.py
@@ -81,7 +81,11 @@ def process_with_config(file_name, config_json, output_file=None):
             return json.dumps(dataset)
 
     except Exception as e:
-        raise Exception(f"Failed to process data: {str(e)}")
+        # `from None` suppresses the implicit exception chain: without it, the
+        # formatted traceback that reaches the JS side (via Pyodide's PythonError)
+        # includes both the original exception's text and this wrapped message,
+        # so any offending-column names inside it (K7) get counted/listed twice.
+        raise Exception(f"Failed to process data: {str(e)}") from None
 
 
 def apply_cleaning(df, config):


### PR DESCRIPTION
## Summary
- Step 5's blocking-error screen and retry toast had leftover German text ("Deine hochgeladenen Daten..." / "Verarbeitung wird erneut gestartet...") — translated to English.
- Fixed the K7 "too many distinct values" message sometimes listing the same offending column twice (e.g. "2 columns ... show_id (9000), show_id (9000)"). Root cause: `preprocessing_processor_config.py`'s outer `except` re-raised without `from None`, so Pyodide's formatted traceback repeated the offender text (original exception + wrapper), and the classifier's regex matched it twice. Fixed at the source, plus a defensive dedupe in `classifyProcessingError`.

## Test plan
- [x] `ng test --include=**/wizard-error-classes.spec.ts` — 23/23 pass, including new regression test for the repeated-column-mention scenario
- [x] `npm run build` — succeeds (pre-existing bundle-budget warning only)
- [x] Manual: Step 5 → trigger a blocking error → confirm English text · Location: Step 5 error screen · Expected: "Your uploaded data and all settings are still there — nothing was lost."
- [x] Manual: Step 5 → click "Try again" → confirm toast reads "Restarting processing…"